### PR TITLE
Add Python 3 to CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.4"
+matrix:
+  allow_failures:
+    - python: "2.7"
+    - python: "3.4"
+  fast_finish: true
+
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
   - pip install MySQL-python


### PR DESCRIPTION
- Add Python 3.4 to CI build matrix so that we can see what would need to
  change to allow support for Python 3.
- Set build matrix to allow failures for Python 2.7 and 3.4 as they do not
  need to be supported at the moment.
- Set CI file to fast finish so we don't have to wait for builds of
  versions that are allowed to fail.

See "Details" in merge box for example.
