### PR TITLE
Spec file tidy

### DIFF
--- a/apel.spec
+++ b/apel.spec
@@ -5,7 +5,7 @@
 
 Name:           apel
 Version:        1.3.1
-%define releasenumber 0.1.alpha1
+%define releasenumber 0.2.alpha2
 Release:        %{releasenumber}%{?dist}
 Summary:        APEL packages
 


### PR DESCRIPTION
Some improvements to the spec file.
- I've defined a 'releasenumber' macro so that the release number only needs to be manually changed in one place, rather than three we had before (due to the change in versioning scheme).
- I'm combined directives that apply to the same file in the 'files' sections which should solve the warnings that are raised during the build about files appearing more than once.
- Sections breaks for better readability.

Test built successfully on both SL5 and SL6.
