### PR TITLE
Add check for accept queue before trying to purge

### DIFF
--- a/apel/db/loader/loader.py
+++ b/apel/db/loader/loader.py
@@ -173,6 +173,7 @@ class Loader(object):
                 # Remove empty dirs and unlock msgs older than 5 min (default)
                 self._inq.purge()
                 self._rejectq.purge()
+                # The accept queue is only created if _save_msgs is true.
                 if self._save_msgs:
                     self._acceptq.purge()
             except OSError, e:
@@ -196,4 +197,3 @@ class Loader(object):
         self._apeldb.load_records(records, source=signer)
         
         log.debug('Records successfully loaded')
- 


### PR DESCRIPTION
Resolves #33.
- Change dirq tidying code to check that accepted messages are set to be
  saved before trying to purge the accept queue as this queue is only
  created if accected messages are being saved.
