### PR TITLE
GridEngine multiplier capabilities for cputime/walltime.

### DIFF
--- a/apel/parsers/sge.py
+++ b/apel/parsers/sge.py
@@ -12,7 +12,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
    @author: Konrad Jopek
 '''
 
@@ -20,52 +20,101 @@ from apel.db.records.event import EventRecord
 from apel.parsers import Parser
 
 import logging
+import subprocess
+import xml.dom.minidom
 
 log = logging.getLogger(__name__)
+
+class MultiplierError(Exception):
+    pass
 
 class SGEParser(Parser):
     '''
     SGEParser parses files from SGE batch system.
-    
+
     Please, refer to:
     http://jra1mw.cvs.cern.ch/cgi-bin/jra1mw.cgi/org.glite.apel.sge/src/org/glite/apel/sge/EventLogParser.java?revision=1.8&view=markup
     if you are interested how the old parser worked.
-    
+
     Parser is based on this specification: http://manpages.ubuntu.com/manpages/lucid/man5/sge_accounting.5.html
-    
+
     Example line from SGE:
     dteam:testce.test:dteam:dteam041:STDIN:43:sge:
     19:1200093286:1200093294:1200093295:0:0:1:0:0:0.000000:0:0:0:0:
     46206:0:0:0.000000:0:0:0:0:337:257:NONE:defaultdepartment:NONE:1
     :0:0.090000:0.000213:0.000000:-U dteam -q dteam:0.000000:NONE:30171136.000000
-    
+
     Line was splitted, if you want to rejoin use empty string as a joiner.
     '''
-    
+
     def __init__(self, site, machine_name, mpi):
         Parser.__init__(self, site, machine_name, mpi)
         if self._mpi:
             log.warn('SGE MPI accounting may be incomplete.')
-        
-    
+        self.multipliers = self._load_multipliers()
+
+    def _load_multipliers(self):
+        '''
+        Returns a dictionary {hostname: {cputmult: <value>, wallmult: <value>}}.
+
+        Hosts with no cputmult/wallmult definitions are ignored.
+        '''
+        d = {}
+        try:
+            p = subprocess.Popen(["qhost", "-F", "-xml"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            out, err = p.communicate()
+            if p.returncode != 0:
+                raise MultiplierError(err)
+        except (OSError, MultiplierError):
+            return {}
+
+        xml_str = xml.dom.minidom.parseString(out)
+        hosts = xml_str.getElementsByTagName("host")
+
+        for host in hosts:
+            host_name = dict(host.attributes.items())["name"]
+            for resource in host.getElementsByTagName("resourcevalue"):
+                resource_name = dict(resource.attributes.items())["name"]
+                if resource_name in ["cputmult", "wallmult"]:
+                    try:
+                        resource_value = float(resource.childNodes[0].data)
+                        d[host_name][resource_name] = resource_value
+                    except ValueError:
+                        pass # float conversion
+                    except KeyError:
+                        d[host_name] = {resource_name: resource_value}
+        return d
+
+    def _get_cpu_multiplier(self, node):
+        '''
+        Returns a given node's cputmult complex. Defaults to 1.
+        '''
+        return self.multipliers.get(node, self.multipliers).get("cputmult", 1.0)
+
+    def _get_wall_multiplier(self, node):
+        '''
+        Returns a given node's wallmult complex. Defaults to 1.
+        '''
+        return self.multipliers.get(node, self.multipliers).get("wallmult", 1.0)
+
     def parse(self, line):
         '''
         Parses single line from accounting log file.
         '''
         values = line.split(':')
-        
+
         if self._mpi:
             procs = int(values[34])
         else:
             procs = 0
-            
+
         mapping = {'Site'           : lambda x: self.site_name,
                   'JobName'         : lambda x: x[5],
                   'LocalUserID'     : lambda x: x[3],
                   'LocalUserGroup'  : lambda x: x[2],
                   # int() can't parse strings like '1.000'
-                  'WallDuration'    : lambda x: int(round(float(x[13]))),
-                  'CpuDuration'     : lambda x: int(round(float(x[36]))), 
+                  'WallDuration'    : lambda x: int(round(float(x[13]))*self._get_wall_multiplier(x[1])),
+                  'CpuDuration'     : lambda x: int(round(float(x[36]))*self._get_cpu_multiplier(x[1])),
                   'StartTime'       : lambda x: int(x[9]),
                   'StopTime'        : lambda x: int(x[10]),
                   'Infrastructure'  : lambda x: "APEL-CREAM-SGE",
@@ -75,18 +124,18 @@ class SGEParser(Parser):
                   'Processors'      : lambda x: procs,
                   # Apparently can't get the number of WNs.
                   'NodeCount'       : lambda x: 0}
-    
+
         record = EventRecord()
         data = {}
-        
+
         for key in mapping:
             data[key] = mapping[key](values)
-        
+
         assert data['CpuDuration'] >= 0, 'Negative CpuDuration value'
         assert data['WallDuration'] >= 0, 'Negative WallDuration value'
         assert data['StopTime'] > 0, 'Zero epoch time for field StopTime'
-        
-        
+
+
         record.set_all(data)
-        
+
         return record

--- a/test/test_sge.py
+++ b/test/test_sge.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from unittest import TestCase
-from apel.parsers import SGEParser
+import mock
+import apel.parsers
+import apel.parsers.sge
 
 class ParserSGETest(TestCase):
     '''
@@ -8,7 +10,7 @@ class ParserSGETest(TestCase):
     '''
     
     def setUp(self):
-        self.parser = SGEParser('testSite', 'testHost', True)
+        self.parser = apel.parsers.SGEParser('testSite', 'testHost', True)
     
     def test_parse_line(self):
         
@@ -87,4 +89,172 @@ class ParserSGETest(TestCase):
         
             for key in cases[line].keys():
                 self.assertEqual(cont[key], cases[line][key], "%s != %s for key %s" % (cont[key], cases[line][key], key))
+
+    def test_parse_line_with_multiplier(self):
+        '''
+        Multiplier (cpu, wall) functionality testing.
+        '''
+        cputmult = 2.0
+        wallmult = 2.0
+        line = ('large:compute-4-19.local:csic:csfiylfl:s001.sh:6972834:sge:0:1318560244:1318560254:1318740255:'
+        '100:138:180001:0.005999:0.012998:1448.000000:0:0:0:0:1060:0:0:0.000000:168:0:0:0:89:2:por_defecto:'
+        'defaultdepartment:mpi:9:0:1026706.540000:60207.223310:0.001862:-u csfiylfl -q big_small*,large*,offline*,small* -l '
+        'arch=x86_64,h_fsize=1G,h_rt=180300,h_stack=16M,h_vmem=1124M,num_proc=1,processor=opteron_6174,s_rt=180000,s_vmem=1G '
+        '-pe mpi 9:0.000000:NONE:821923840.000000:0:0')
         
+        line_values = {"JobName": "6972834", 
+                        "LocalUserID":"csfiylfl", 
+                        "LocalUserGroup": "csic", 
+                        "WallDuration": int(wallmult*180001), 
+                        "CpuDuration": int(cputmult*1026707),
+                        "StartTime": datetime.utcfromtimestamp(1318560254),
+                        "StopTime": datetime.utcfromtimestamp(1318740255),
+                        "MemoryReal":63131849389,
+                        "MemoryVirtual": 821923840,
+                        "NodeCount": 0,
+                        "Processors": 9
+                        }
+
+        with mock.patch.object(apel.parsers.sge.SGEParser,'_load_multipliers') as fake:
+            fake.return_value = { "compute-4-19.local": { "cputmult": cputmult, "wallmult": wallmult }}
+            parser = apel.parsers.sge.SGEParser('testSite', 'testHost', True)
+            record = parser.parse(line)
+            cont = record._record_content
+            for k,v in line_values.iteritems():
+                self.assertEqual(v, cont[k])
+
+    def test_get_cpu_multiplier(self):
+        '''
+        Testing _get_cpu_multiplier() function with the following arguments:
+            - Empty dictionary.
+            - Dictionary with key 'cputmult'.
+            - Dictionary with keys 'cputmult' and 'wallmult'.
+        '''
+        for d,v in [({}, 1.0),
+                  ({"compute-4-19.local": {"cputmult": 2.0}}, 2.0),
+                  ({"compute-4-19.local": {"cputmult": 2.0, "wallmult": 2.0}}, 2.0)]:
+            with mock.patch.object(apel.parsers.sge.SGEParser,'_load_multipliers') as fake:
+                fake.return_value = d
+                parser = apel.parsers.sge.SGEParser('testSite', 'testHost', True)
+                self.assertEqual(v, parser._get_cpu_multiplier('compute-4-19.local'))
+    
+    def test_get_wall_multiplier(self):
+        '''
+        Testing _get_wall_multiplier() function with the following arguments:
+            - Empty dictionary.
+            - Dictionary with key 'wallmult'.
+            - Dictionary with keys 'cputmult' and 'wallmult'.
+        '''
+        for d,v in [({}, 1.0),
+                  ({"compute-4-19.local": {"wallmult": 2.0}}, 2.0),
+                  ({"compute-4-19.local": {"cputmult": 2.0, "wallmult": 2.0}}, 2.0)]:
+            with mock.patch.object(apel.parsers.sge.SGEParser,'_load_multipliers') as fake:
+                fake.return_value = d
+                parser = apel.parsers.sge.SGEParser('testSite', 'testHost', True)
+                self.assertEqual(v, parser._get_wall_multiplier('compute-4-19.local'))
+    
+    def test_load_multipliers_qhost_error(self):
+        '''
+        Testing load_multipliers() when qhost command exits with error. 
+        '''
+        with mock.patch('apel.parsers.sge.subprocess') as subprocess:
+            subprocess.Popen.return_value.returncode = 1
+            subprocess.Popen.return_value.communicate = lambda: ('', 'foo')
+            parser = apel.parsers.SGEParser('testSite', 'testHost', True)
+            self.assertEqual({}, parser._load_multipliers())
+
+    def test_load_multipliers_xml_unique(self):
+        '''
+        Testing either 'cputmult' or 'wallmult' appearances in the following conditions:
+            - 'cputmult' with a valid (float) value.
+            - 'cputmult' with a non-valid (string) value.
+            - 'wallmult' with a valid (float) value.
+            - 'wallmult' with a non-valid (string) value.
+        '''
+        qhost_output = """<?xml version='1.0'?>
+            <qhost xmlns:xsd="http://arc.liv.ac.uk/repos/darcs/sge/source/dist/util/resources/schemas/qhost/qhost.xsd">
+             <host name='global'>
+               <hostvalue name='arch_string'>-</hostvalue>
+               <hostvalue name='num_proc'>-</hostvalue>
+               <hostvalue name='m_socket'>-</hostvalue>
+               <hostvalue name='m_core'>-</hostvalue>
+               <hostvalue name='m_thread'>-</hostvalue>
+               <hostvalue name='load_avg'>-</hostvalue>
+               <hostvalue name='mem_total'>-</hostvalue>
+               <hostvalue name='mem_used'>-</hostvalue>
+               <hostvalue name='swap_total'>-</hostvalue>
+               <hostvalue name='swap_used'>-</hostvalue>
+             </host>
+             <host name='compute-4-19.local'>
+               <hostvalue name='arch_string'>lx-amd64</hostvalue>
+               <hostvalue name='num_proc'>24</hostvalue>
+               <hostvalue name='m_socket'>24</hostvalue>
+               <hostvalue name='m_core'>24</hostvalue>
+               <hostvalue name='m_thread'>24</hostvalue>
+               <hostvalue name='load_avg'>24.22</hostvalue>
+               <hostvalue name='mem_total'>45.1G</hostvalue>
+               <hostvalue name='mem_used'>22.4G</hostvalue>
+               <hostvalue name='swap_total'>10.0G</hostvalue>
+               <hostvalue name='swap_used'>132.5M</hostvalue>
+               <resourcevalue name='%s' dominance='hf'>%s</resourcevalue>
+             </host>
+            </qhost>
+        """
+        for c,v,d in [('cputmult', 2.2, {'compute-4-19.local': {'cputmult': 2.2}}),
+                      ('cputmult', 'foo', {}),
+                      ('wallmult', 2.2, {'compute-4-19.local': {'wallmult': 2.2}}),
+                      ('wallmult', 'foo', {})]:
+            with mock.patch('apel.parsers.sge.subprocess') as subprocess:
+                subprocess.Popen.return_value.returncode = 0
+                subprocess.Popen.return_value.communicate = lambda: (qhost_output % (c,v), '')
+                parser = apel.parsers.SGEParser('testSite', 'testHost', True)
+                self.assertEqual(d, parser._load_multipliers())
+        
+    def test_load_multipliers_xml_both(self):
+        '''
+        For the sake of completeness with regard to the function above: testing both 'cputmult' and 'wallmult'
+        appearances coexisting in the following conditions:
+            - 'cputmult' with a valid (float) value ; 'wallmult' with a non-valid (string) value.
+            - 'cputmult' with a non-valid (string) value ; 'wallmult' with a valid (float) value.
+            - both 'cputmult' and 'wallmult' with a valid (float) value.
+            - both 'cputmult' and 'wallmult' with a non-valid (string) value.
+        '''
+        qhost_output = """<?xml version='1.0'?>
+            <qhost xmlns:xsd="http://arc.liv.ac.uk/repos/darcs/sge/source/dist/util/resources/schemas/qhost/qhost.xsd">
+             <host name='global'>
+               <hostvalue name='arch_string'>-</hostvalue>
+               <hostvalue name='num_proc'>-</hostvalue>
+               <hostvalue name='m_socket'>-</hostvalue>
+               <hostvalue name='m_core'>-</hostvalue>
+               <hostvalue name='m_thread'>-</hostvalue>
+               <hostvalue name='load_avg'>-</hostvalue>
+               <hostvalue name='mem_total'>-</hostvalue>
+               <hostvalue name='mem_used'>-</hostvalue>
+               <hostvalue name='swap_total'>-</hostvalue>
+               <hostvalue name='swap_used'>-</hostvalue>
+             </host>
+             <host name='compute-4-19.local'>
+               <hostvalue name='arch_string'>lx-amd64</hostvalue>
+               <hostvalue name='num_proc'>24</hostvalue>
+               <hostvalue name='m_socket'>24</hostvalue>
+               <hostvalue name='m_core'>24</hostvalue>
+               <hostvalue name='m_thread'>24</hostvalue>
+               <hostvalue name='load_avg'>24.22</hostvalue>
+               <hostvalue name='mem_total'>45.1G</hostvalue>
+               <hostvalue name='mem_used'>22.4G</hostvalue>
+               <hostvalue name='swap_total'>10.0G</hostvalue>
+               <hostvalue name='swap_used'>132.5M</hostvalue>
+               <resourcevalue name='cputmult' dominance='hf'>%s</resourcevalue>
+               <resourcevalue name='wallmult' dominance='hf'>%s</resourcevalue>
+             </host>
+            </qhost>
+        """
+        for c,w,d in [(2.2, 'foo', {'compute-4-19.local': {'cputmult': 2.2}}),
+                      ('foo', 2.2, {'compute-4-19.local': {'wallmult': 2.2}}),
+                      (2.2, 2.2, {'compute-4-19.local': {'cputmult': 2.2, 'wallmult': 2.2}}),
+                      ('foo', 'bar', {})]:
+            with mock.patch('apel.parsers.sge.subprocess') as subprocess:
+                subprocess.Popen.return_value.returncode = 0
+                subprocess.Popen.return_value.communicate = lambda: (qhost_output % (c,w), '')
+                parser = apel.parsers.SGEParser('testSite', 'testHost', True)
+                self.assertEqual(d, parser._load_multipliers())


### PR DESCRIPTION
GridEngine scheduler does not include any built-in solution
to normalize the cputime/walltime numbers in a heterogeneous
cluster. This change extends GridEngine's APEL parser to
normalize these values according to the nodes' definition.

For each accounting record, cputime/walltime are computed based
on 'cputmult' and 'wallmult' (a la PBS) complex values set in
the node's definiton. If no multiplier is found, defaults
to 1.
