### PR TITLE
Add method stubs to base ApelDb class

### DIFF
--- a/apel/db/apeldb.py
+++ b/apel/db/apeldb.py
@@ -58,20 +58,71 @@ class ApelDb(object):
 
     def test_connection(self):
         '''Connects to the database then closes the connection.'''
-        pass
-    
-    def load_records(self, record_list, source):
+        raise NotImplementedError
+
+    def load_records(self, record_list, replace=True, source=None):
         '''Given a list of records, and the DN of the sender,
         loads them into the database.'''
-        pass
-    
-    def get_records(self, record_class, query=None):
+        raise NotImplementedError
+
+    def get_records(self, record_type, table_name=None, query=None,
+                    rec_number=1000):
         '''
         Returns records from database with given record type.
         Query object specifies which rows from database should be loaded.
         '''
-        pass
-    
+        raise NotImplementedError
+
+    def check_duplicate_sites(self):
+        """
+        Check that records from same site not in both JobRecords and Summaries.
+        """
+        raise NotImplementedError
+
+    def summarise_jobs(self):
+        """
+        Aggregate data from JobRecords table and put results in
+        HybridSuperSummaries table by calling a stored procedure.
+        """
+        raise NotImplementedError
+
+    def normalise_summaries(self):
+        """
+        Normalise data from Summaries and insert into HybridSuperSummaries.
+        """
+        raise NotImplementedError
+
+    def copy_summaries(self):
+        """
+        Copy summaries from NormalisedSummaries to HybridSuperSummaries table.
+        """
+        raise NotImplementedError
+
+    def summarise_cloud(self):
+        """
+        Aggregate CloudRecords table and put results in CloudSummaries table.
+        """
+        raise NotImplementedError
+
+    def join_records(self):
+        """
+        Join data from BlahdRecords and EventRecords tables into JobRecords.
+        """
+        raise NotImplementedError
+
+    def create_local_jobs(self):
+        """
+        Create local jobs by calling a stored procedure.
+        """
+        raise NotImplementedError
+
+    def update_spec(self, site, ce, spec_level_type, spec_level):
+        """
+        Compare existing data from database to given values and update
+        SpecRecords table if neccessary.
+        """
+        raise NotImplementedError
+
 
 class Query(object):
     '''

--- a/apel/db/apeldb.py
+++ b/apel/db/apeldb.py
@@ -58,12 +58,14 @@ class ApelDb(object):
 
     def test_connection(self):
         '''Connects to the database then closes the connection.'''
-        raise NotImplementedError
+        raise NotImplementedError("Database backend class should implement this"
+                                  " method")
 
     def load_records(self, record_list, replace=True, source=None):
         '''Given a list of records, and the DN of the sender,
         loads them into the database.'''
-        raise NotImplementedError
+        raise NotImplementedError("Database backend class should implement this"
+                                  " method")
 
     def get_records(self, record_type, table_name=None, query=None,
                     rec_number=1000):
@@ -71,57 +73,66 @@ class ApelDb(object):
         Returns records from database with given record type.
         Query object specifies which rows from database should be loaded.
         '''
-        raise NotImplementedError
+        raise NotImplementedError("Database backend class should implement this"
+                                  " method")
 
     def check_duplicate_sites(self):
         """
         Check that records from same site not in both JobRecords and Summaries.
         """
-        raise NotImplementedError
+        raise NotImplementedError("Database backend class should implement this"
+                                  " method")
 
     def summarise_jobs(self):
         """
         Aggregate data from JobRecords table and put results in
         HybridSuperSummaries table by calling a stored procedure.
         """
-        raise NotImplementedError
+        raise NotImplementedError("Database backend class should implement this"
+                                  " method")
 
     def normalise_summaries(self):
         """
         Normalise data from Summaries and insert into HybridSuperSummaries.
         """
-        raise NotImplementedError
+        raise NotImplementedError("Database backend class should implement this"
+                                  " method")
 
     def copy_summaries(self):
         """
         Copy summaries from NormalisedSummaries to HybridSuperSummaries table.
         """
-        raise NotImplementedError
+        raise NotImplementedError("Database backend class should implement this"
+                                  " method")
 
     def summarise_cloud(self):
         """
         Aggregate CloudRecords table and put results in CloudSummaries table.
         """
-        raise NotImplementedError
+        raise NotImplementedError("Database backend class should implement this"
+                                  " method")
 
     def join_records(self):
         """
         Join data from BlahdRecords and EventRecords tables into JobRecords.
         """
-        raise NotImplementedError
+        raise NotImplementedError("Database backend class should implement this"
+                                  " method")
 
     def create_local_jobs(self):
         """
         Create local jobs by calling a stored procedure.
         """
-        raise NotImplementedError
+        raise NotImplementedError("Database backend class should implement this"
+                                  " method")
 
     def update_spec(self, site, ce, spec_level_type, spec_level):
         """
         Compare existing data from database to given values and update
         SpecRecords table if neccessary.
         """
-        raise NotImplementedError
+        raise NotImplementedError("Database backend class should implement this"
+                                  " method")
 
 
 class Query(object):


### PR DESCRIPTION
These changes are mainly tidy-up as all that's being changed is that the class that invokes the actual database backend classes is being given method stubs that have the right signature (arguments). They all now raise `NotImplementedError` if they're called directly as the backend classes should override these.

(Also improves code health.)

It's not strictly an "abstract base class", though it's kind of acting like one.