### PR TITLE
Reduce logging level for purge OSError

### DIFF
--- a/apel/db/loader/loader.py
+++ b/apel/db/loader/loader.py
@@ -177,7 +177,7 @@ class Loader(object):
                 if self._save_msgs:
                     self._acceptq.purge()
             except OSError, e:
-                log.error('OSError raised while purging message queues: %s' % e)
+                log.warn('OSError raised while purging message queues: %s' % e)
 
         log.debug("Loader run finished.")
         log.debug("======================")


### PR DESCRIPTION
Resolves #51 for APEL (SSM has same issue).
- Reduce logging level for purge OSError as it is usually raised when one
  of the temporary directories is not empty (i.e. still being written to
  by SSM) which is not really a problem.

Example:

```
2014-11-10 10:39:10,649 - loader - ERROR - OSError raised while purging message queues: cannot rmdir(/var/spool/apel/incoming/temporary/546095ce8f4d19): [Errno 39] Directory not empty: '/var/spool/apel/incoming/temporary/546095ce8f4d19'
```
