### PR TITLE
Add Month and Year to CloudSummaries primary key

### DIFF
--- a/schemas/cloud.sql
+++ b/schemas/cloud.sql
@@ -117,7 +117,7 @@ CREATE TABLE CloudSummaries (
   
   PublisherDNID VARCHAR(255),
 
-  PRIMARY KEY (SiteID, GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId)
+  PRIMARY KEY (SiteID, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId)
 
 );
 


### PR DESCRIPTION
Resolves #58.

- Add the columns Month and Year to the primary key for the CloudSummaries
  table as these columns are part of the GROUP BY used to create the
  summaries and so should be in the primary key, otherwise summaries will
  overwrite each other.