### PR TITLE
Keep DNs if no valid response from GOCDB

### DIFF
--- a/bin/retrieve_dns.py
+++ b/bin/retrieve_dns.py
@@ -219,8 +219,8 @@ def runprocess(config_file, log_config_file):
                          (cfg.expire_hours * 3600)):
         log.warn('Failed to update DNs from GOCDB. Will not modify DNs file.')
         log.info("auth will exit.")
-        sys.exit(1)
         log.info(LOG_BREAK)
+        sys.exit(1)
 
     # get the DNs from the additional file
     try:
@@ -249,8 +249,8 @@ def runprocess(config_file, log_config_file):
         log.warn("Failed to open file %s for writing.", cfg.dn_file)
         log.warn("Check the configuration.")
         log.warn("auth will exit.")
-        sys.exit(1)
         log.info(LOG_BREAK)
+        sys.exit(1)
 
     added = 0
     for dn in dns:

--- a/bin/retrieve_dns.py
+++ b/bin/retrieve_dns.py
@@ -177,11 +177,11 @@ def verify_dn(dn):
     # it should begin with a slash
     if dn.find('/') != 0:
         return False
-    # Check there are at least two bits
-    parts = dn.split('/')
-    if len(parts) < 2:
+    # Check that there are at least two parts to the DN. There should be 3 after
+    # the .split as an empty string is considered to be before the leading '/'.
+    if len(dn.split('/')) <= 2:
         return False
-     
+
     return True
 
 

--- a/bin/retrieve_dns.py
+++ b/bin/retrieve_dns.py
@@ -251,17 +251,20 @@ def runprocess(config_file, log_config_file):
         log.warn("auth will exit.")
         sys.exit(1)
         log.info(LOG_BREAK)
-        
+
     added = 0
     for dn in dns:
         if verify_dn(dn):
             new_dn_file.write(dn)
             new_dn_file.write('\n')
             added += 1
+        elif dn.lstrip().startswith("#"):
+            # Ignore comment lines starting with "#"
+            log.debug("Comment ignored: %s", dn)
         else:
             # We haven't accepted the DN, so write it to the log file.
             log.warning("DN not valid and won't be added: " + dn)
-                
+
     new_dn_file.close()
 
     log.info("%s DNs have been written to %s.", added, cfg.dn_file)

--- a/conf/auth.cfg
+++ b/conf/auth.cfg
@@ -17,7 +17,7 @@ proxy = http://wwwcache.rl.ac.uk:8080
 
 # This is the maximum duration previously retrieved DNs will be kept if auth
 # can't retrive fresh data from GOCDB. Setting to 0 disables this retention.
-expire_hours = 4
+expire_hours = 2
 
 [logging]
 logfile = /var/log/apel/auth.log

--- a/conf/auth.cfg
+++ b/conf/auth.cfg
@@ -15,6 +15,10 @@ allowed-dns = /etc/apel/dns
 # Proxy settings - keep the format below
 proxy = http://wwwcache.rl.ac.uk:8080
 
+# This is the maximum duration previously retrieved DNs will be kept if auth
+# can't retrive fresh data from GOCDB. Setting to 0 disables this retention.
+expire_hours = 4
+
 [logging]
 logfile = /var/log/apel/auth.log
 level = INFO

--- a/test/test_retrieve_dns.py
+++ b/test/test_retrieve_dns.py
@@ -1,0 +1,57 @@
+import logging
+import os
+import tempfile
+import unittest
+
+import mock
+
+import bin.retrieve_dns
+
+
+logging.basicConfig(level=logging.INFO)
+
+
+class RetrieveDnsTestCase(unittest.TestCase):
+
+    def setUp(self):
+        # Mock out logging
+        mock.patch('bin.retrieve_dns.set_up_logging', autospec=True).start()
+
+        # Mock out config
+        mock_config = mock.patch('bin.retrieve_dns.get_config', autospec=True).start()
+
+        # Mock out retrieving xml
+        self.mock_xml = mock.patch('bin.retrieve_dns.get_xml', autospec=True).start()
+
+        # Set up temp files
+        self.files = {}
+        for item in ('dn', 'extra', 'ban'):
+            self.files[item] = dict(zip(('handle', 'path'), tempfile.mkstemp()))
+            os.write(self.files[item]['handle'], '/wobble')
+        for item in self.files.values():
+            os.close(item['handle'])
+
+        # Set up config using temp files
+        c = bin.retrieve_dns.Configuration()
+        c.dn_file = self.files['dn']['path']
+        c.extra_dns = self.files['extra']['path']
+        c.banned_dns = self.files['ban']['path']
+        mock_config.return_value = c
+
+    def test_basics(self):
+        self.mock_xml.return_value = "<HOSTDN>/wibble</HOSTDN>"
+        bin.retrieve_dns.runprocess("fakefile", "fakefile")
+        dns = open(self.files['dn']['path'])
+        self.assertEqual(dns.read(), '/wibble\n')
+        dns.close()
+
+    def tearDown(self):
+        # Delete temp files
+        for item in self.files.values():
+            os.remove(item['path'])
+
+        mock.patch.stopall()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_retrieve_dns.py
+++ b/test/test_retrieve_dns.py
@@ -8,7 +8,7 @@ import mock
 import bin.retrieve_dns
 
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.WARN)
 
 
 class RetrieveDnsTestCase(unittest.TestCase):
@@ -18,16 +18,22 @@ class RetrieveDnsTestCase(unittest.TestCase):
         mock.patch('bin.retrieve_dns.set_up_logging', autospec=True).start()
 
         # Mock out config
-        mock_config = mock.patch('bin.retrieve_dns.get_config', autospec=True).start()
+        mock_config = mock.patch('bin.retrieve_dns.get_config',
+                                 autospec=True).start()
 
         # Mock out retrieving xml
-        self.mock_xml = mock.patch('bin.retrieve_dns.get_xml', autospec=True).start()
+        self.mock_xml = mock.patch('bin.retrieve_dns.get_xml',
+                                   autospec=True).start()
 
         # Set up temp files
         self.files = {}
         for item in ('dn', 'extra', 'ban'):
             self.files[item] = dict(zip(('handle', 'path'), tempfile.mkstemp()))
-            os.write(self.files[item]['handle'], '/wobble')
+
+        os.write(self.files['dn']['handle'], "/dn1\n/dn2\n")
+        os.write(self.files['extra']['handle'], "/extra_dn\n/banned_dn")
+        os.write(self.files['ban']['handle'], "/banned_dn")
+
         for item in self.files.values():
             os.close(item['handle'])
 
@@ -36,20 +42,40 @@ class RetrieveDnsTestCase(unittest.TestCase):
         c.dn_file = self.files['dn']['path']
         c.extra_dns = self.files['extra']['path']
         c.banned_dns = self.files['ban']['path']
+        c.expire_hours = 1
         mock_config.return_value = c
 
     def test_basics(self):
-        self.mock_xml.return_value = "<HOSTDN>/wibble</HOSTDN>"
-        bin.retrieve_dns.runprocess("fakefile", "fakefile")
+        self.mock_xml.return_value = """<results>
+        <SERVICE_ENDPOINT><HOSTDN>/basic_dn</HOSTDN></SERVICE_ENDPOINT>
+        <SERVICE_ENDPOINT><HOSTDN>/banned_dn</HOSTDN></SERVICE_ENDPOINT>
+        </results>"""
+        bin.retrieve_dns.runprocess("fake_config_file", "fake_log_config_file")
         dns = open(self.files['dn']['path'])
-        self.assertEqual(dns.read(), '/wibble\n')
-        dns.close()
+        try:
+            self.assertEqual(dns.read(), "/basic_dn\n/extra_dn\n")
+        finally:
+            dns.close()
+
+    def test_gocdb_fail(self):
+        """
+        If there isn't a good response from GOCDB we want to keep the old
+        list of DNs for a configurable amount of time until a good response is
+        obtained.
+        """
+        self.mock_xml.return_value = ""
+        self.assertRaises(SystemExit, bin.retrieve_dns.runprocess, "fake_config_file", "fake_log_config_file")
+        dns = open(self.files['dn']['path'])
+        try:
+            self.assertEqual(dns.read(), "/dn1\n/dn2\n")
+        finally:
+            dns.close()
 
     def tearDown(self):
         # Delete temp files
         for item in self.files.values():
             os.remove(item['path'])
-
+        # Stop all patchers so that they're reset for the next test
         mock.patch.stopall()
 
 


### PR DESCRIPTION
Resolves #60.

**Main changes:**
- Change `retrieve_dns` to keep the previous DN list if there isn't a valid
  response from GOCDB. This is so that messages aren't rejected just
  because there was a small period where GOCDB is unreachable.
- Add config option to alter the expiry time of the DN list when the above
  situation occurs.
- Add lots of test cases for `retrieve_dns`. :triumph:

**Minor changes:**
- Change `retrieve_dns` to only print a debug message when it encounters a
  comment line starting with "#" as there used to always be a few that
  would generate warnings unnecessarily.
- Reorder `sys.exit` and `log.info` in `retrieve_dns` so that the logging call
  is first otherwise it is never reached.