### PR TITLE
Add method stubs to base ApelDb class

### DIFF
--- a/apel/db/apeldb.py
+++ b/apel/db/apeldb.py
@@ -64,14 +64,64 @@ class ApelDb(object):
         '''Given a list of records, and the DN of the sender,
         loads them into the database.'''
         pass
-    
-    def get_records(self, record_class, query=None):
+
+    def get_records(self, record_type, table_name, query, rec_number):
         '''
         Returns records from database with given record type.
         Query object specifies which rows from database should be loaded.
         '''
         pass
-    
+
+    def check_duplicate_sites(self):
+        """
+        Check that records from same site not in both JobRecords and Summaries.
+        """
+        pass
+
+    def summarise_jobs(self):
+        """
+        Aggregate data from JobRecords table and put results in
+        HybridSuperSummaries table by calling a stored procedure.
+        """
+        pass
+
+    def normalise_summaries(self):
+        """
+        Normalise data from Summaries and insert into HybridSuperSummaries.
+        """
+        pass
+
+    def copy_summaries(self):
+        """
+        Copy summaries from NormalisedSummaries to HybridSuperSummaries table.
+        """
+        pass
+
+    def summarise_cloud(self):
+        """
+        Aggregate CloudRecords table and put results in CloudSummaries table.
+        """
+        pass
+
+    def join_records(self):
+        """
+        Join data from BlahdRecords and EventRecords tables into JobRecords.
+        """
+        pass
+
+    def create_local_jobs(self):
+        """
+        Create local jobs by calling a stored procedure.
+        """
+        pass
+
+    def update_spec(self, site, ce, spec_level_type, spec_level):
+        """
+        Compare existing data from database to given values and update
+        SpecRecords table if neccessary.
+        """
+        pass
+
 
 class Query(object):
     '''


### PR DESCRIPTION
This is a new and improved version of #52 but this time just using `pass` instead of `raise NotImplementedError` so that it doesn't interfere with the Oracle back-end. Changes include:

- Add method stubs to base ApelDb class to show what should be implemented
  by database backends.
- Change method signature.