### PR TITLE
Univa Grid Engine timestamp option

### DIFF
--- a/apel/db/records/record.py
+++ b/apel/db/records/record.py
@@ -158,7 +158,6 @@ class Record(object):
                 # We accept ints or floats as seconds since the epoch
                 try:
                     value = int(value)
-                    return datetime.utcfromtimestamp(value)
                 except ValueError:
                     # Not a datetime or an int, so it has to be a string representation.
                     # We get ISO format dates when parsing CAR or StAR.
@@ -170,6 +169,11 @@ class Record(object):
                         return dt
                     except ValueError: # Failed to parse timestamp
                         raise InvalidRecordException('Unknown datetime format!: %s' % value)
+                try:
+                    return datetime.utcfromtimestamp(value)
+                except ValueError, e:
+                    # Given timestamp is probably out of range
+                    raise InvalidRecordException(e)
             else:
                 return value
         except ValueError:

--- a/apel/parsers/lsf.py
+++ b/apel/parsers/lsf.py
@@ -73,7 +73,8 @@ class LSFParser(Parser):
         Set to true if you want to scale CPU duration and wall duration
         according to the 'HostFactor' value in the log file.
         '''
-        log.info('Will scale durations according to host factor specified in log file.')
+        if scale_hf:
+            log.info('Will scale durations according to host factor specified in log file.')
         self._scale_hf = scale_hf
         
     def parse(self, line):

--- a/apel/parsers/sge.py
+++ b/apel/parsers/sge.py
@@ -55,7 +55,18 @@ class SGEParser(Parser):
 
         # This should be set to True in parser.py for versions of Grid Engine
         # using millisecond timestamps (i.e. Univa Grid Engine 8.2.0+).
-        self.ms_timestamps = False
+        self._ms_timestamps = False
+
+    def set_ms_timestamps(self, use_ms):
+        """
+        Set _ms_timestamps to True or False.
+
+        This decides if timestamps will be treated as being in milliseconds (in
+        which case they'll need to be converted back to seconds).
+        """
+        if use_ms:
+            log.info('Will treat GE timestamps as being in milliseconds.')
+        self._ms_timestamps = use_ms
 
     def _load_multipliers(self):
         '''
@@ -116,7 +127,7 @@ class SGEParser(Parser):
 
         # If a version of GE that uses millisecond timestamps is being used then
         # set the divisor to convert back to seconds.
-        if self.ms_timestamps:
+        if self._ms_timestamps:
             divisor = 1000
         else:
             divisor = 1

--- a/apel/parsers/sge.py
+++ b/apel/parsers/sge.py
@@ -53,6 +53,10 @@ class SGEParser(Parser):
             log.warn('SGE MPI accounting may be incomplete.')
         self.multipliers = self._load_multipliers()
 
+        # This should be set to True in parser.py for versions of Grid Engine
+        # using millisecond timestamps (i.e. Univa Grid Engine 8.2.0+).
+        self.ms_timestamps = False
+
     def _load_multipliers(self):
         '''
         Returns a dictionary {hostname: {cputmult: <value>, wallmult: <value>}}.
@@ -110,6 +114,13 @@ class SGEParser(Parser):
         else:
             procs = 0
 
+        # If a version of GE that uses millisecond timestamps is being used then
+        # set the divisor to convert back to seconds.
+        if self.ms_timestamps:
+            divisor = 1000
+        else:
+            divisor = 1
+
         mapping = {'Site'           : lambda x: self.site_name,
                   'JobName'         : lambda x: x[5],
                   'LocalUserID'     : lambda x: x[3],
@@ -117,8 +128,8 @@ class SGEParser(Parser):
                   # int() can't parse strings like '1.000'
                   'WallDuration'    : lambda x: int(round(float(x[13]))*self._get_wall_multiplier(x[1])),
                   'CpuDuration'     : lambda x: int(round(float(x[36]))*self._get_cpu_multiplier(x[1])),
-                  'StartTime'       : lambda x: int(x[9]),
-                  'StopTime'        : lambda x: int(x[10]),
+                  'StartTime'       : lambda x: int(round(float(x[9])/divisor)),
+                  'StopTime'        : lambda x: int(round(float(x[10])/divisor)),
                   'Infrastructure'  : lambda x: "APEL-CREAM-SGE",
                   'MachineName'     : lambda x: self.machine_name,
                   'MemoryReal'      : lambda x: int(float(x[37])*1024*1024),  # is this correct?

--- a/bin/parser.py
+++ b/bin/parser.py
@@ -274,13 +274,20 @@ def handle_parsing(log_type, apel_db, cp):
         raise ParserConfigException(e)
     except KeyError, e:
         raise ParserConfigException("Not a valid parser type: %s" % e)
-    
+
+    # Set parser specific options
     if log_type == 'LSF':
         try:
             parser.set_scaling(cp.getboolean('batch', 'scale_host_factor'))
         except ConfigParser.NoOptionError:
             pass
-        
+    elif log_type == 'SGE':
+        try:
+            parser.ms_timestamps(cp.getbooleon('Grid Engine',
+                                               'millisecond_timestamps'))
+        except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
+            pass
+
     # regular expressions for blah log files and for batch log files
     try:
         prefix = cp.get(section, 'filename_prefix')

--- a/bin/parser.py
+++ b/bin/parser.py
@@ -280,12 +280,14 @@ def handle_parsing(log_type, apel_db, cp):
         try:
             parser.set_scaling(cp.getboolean('batch', 'scale_host_factor'))
         except ConfigParser.NoOptionError:
-            pass
+            log.warning("Option 'scale_host_factor' not found in section 'batch"
+                        "'. Will default to 'false'.")
     elif log_type == 'SGE':
         try:
             parser.ms_timestamps = cp.getboolean('batch', 'ge_ms_timestamps')
-        except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
-            pass
+        except ConfigParser.NoOptionError:
+            log.warning("Option 'ge_ms_timestamps' not found in section 'batch'"
+                        " . Will default to 'false'.")
 
     # regular expressions for blah log files and for batch log files
     try:

--- a/bin/parser.py
+++ b/bin/parser.py
@@ -284,7 +284,7 @@ def handle_parsing(log_type, apel_db, cp):
                         "'. Will default to 'false'.")
     elif log_type == 'SGE':
         try:
-            parser.ms_timestamps = cp.getboolean('batch', 'ge_ms_timestamps')
+            parser.set_ms_timestamps(cp.getboolean('batch', 'ge_ms_timestamps'))
         except ConfigParser.NoOptionError:
             log.warning("Option 'ge_ms_timestamps' not found in section 'batch'"
                         " . Will default to 'false'.")

--- a/bin/parser.py
+++ b/bin/parser.py
@@ -283,8 +283,7 @@ def handle_parsing(log_type, apel_db, cp):
             pass
     elif log_type == 'SGE':
         try:
-            parser.ms_timestamps = cp.getboolean('Grid Engine',
-                                                 'millisecond_timestamps')
+            parser.ms_timestamps = cp.getboolean('batch', 'ge_ms_timestamps')
         except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
             pass
 

--- a/bin/parser.py
+++ b/bin/parser.py
@@ -283,8 +283,8 @@ def handle_parsing(log_type, apel_db, cp):
             pass
     elif log_type == 'SGE':
         try:
-            parser.ms_timestamps(cp.getbooleon('Grid Engine',
-                                               'millisecond_timestamps'))
+            parser.ms_timestamps = cp.getboolean('Grid Engine',
+                                                 'millisecond_timestamps')
         except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
             pass
 

--- a/conf/parser.cfg
+++ b/conf/parser.cfg
@@ -44,6 +44,12 @@ subdirs = false
 # 'HostFactor' value in logfiles
 #scale_host_factor = false
 
+[Grid Engine]
+# Univa Grid Engine timestamps changed from seconds to milliseconds in version
+# 8.2.0, so for versions 8.2.0 onwards use 'true'. Other forks of Grid Engine
+# are probably not affected and so should use 'false'.
+millisecond_timestamps = false
+
 [logging]
 logfile = /var/log/apelparser.log
 level = INFO

--- a/conf/parser.cfg
+++ b/conf/parser.cfg
@@ -44,11 +44,10 @@ subdirs = false
 # 'HostFactor' value in logfiles
 #scale_host_factor = false
 
-[Grid Engine]
 # Univa Grid Engine timestamps changed from seconds to milliseconds in version
 # 8.2.0, so for versions 8.2.0 onwards use 'true'. Other forks of Grid Engine
 # are probably not affected and so should use 'false'.
-millisecond_timestamps = false
+ge_ms_timestamps = false
 
 [logging]
 logfile = /var/log/apelparser.log

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1,4 +1,5 @@
 import bz2
+import ConfigParser
 import gzip
 import os
 import re
@@ -51,9 +52,24 @@ class ParserTest(unittest.TestCase):
         finally:
             shutil.rmtree(dir_path)
 
+    def test_handle_parsing(self):
+        """Check handle_parsing in a basic way (i.e. no errors raised)."""
+        # Construct the location of the parser config file.
+        path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..',
+                                            'conf', 'parser.cfg'))
+        # Read the config and fill in empty values.
+        self.cp = ConfigParser.ConfigParser()
+        self.cp.read(path)
+        self.cp.set('site_info', 'site_name', 'TestSite')
+        self.cp.set('site_info', 'lrms_server', 'TestServer')
+        # It's hard to test handle_parsing, but we can check that no erorrs are
+        # raised and that the load_records method is called with an empty list.
+        bin.parser.handle_parsing('SGE', self.mock_db, self.cp)
+        self.mock_db.load_records.assert_called_once_with([])
+
     def tearDown(self):
         self.tf.close()
-        self.patcher.stop()
+        mock.patch.stopall()
 
 
 if __name__ == '__main__':

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -15,11 +15,6 @@ class ParserTest(unittest.TestCase):
 
     def setUp(self):
         self.tf = tempfile.TemporaryFile()
-        #print self.tf.name
-        #self.tf.write('Test text.')
-        ## Reset file position to start so it can be read
-        #self.tf.seek(0)
-        #print self.tf.readline()
         self.patcher = mock.patch('apel.db.apeldb.ApelDb')
         self.mock_db = self.patcher.start()
 

--- a/test/test_record.py
+++ b/test/test_record.py
@@ -1,7 +1,9 @@
-from unittest import TestCase
+import unittest
+
 from apel.db.records import Record, InvalidRecordException
 
-class RecordTest(TestCase):
+
+class RecordTest(unittest.TestCase):
     '''
     Test case for Record
     '''
@@ -34,3 +36,6 @@ class RecordTest(TestCase):
         record._record_content['Test'] = 'value'
         
         self.assertEqual(record.get_field('Test'), 'value')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_sge.py
+++ b/test/test_sge.py
@@ -72,7 +72,30 @@ class ParserSGETest(unittest.TestCase):
                         }
         
         cases[line3] = line3_values
-        
+
+        line4 = ("grid.q:node101.cm.cluster:prdatl:prdatl26:cream_324080374:329"
+                 "4013:sge:0:1404167579:1404169049:1404169408:0:0:359:32.189106"
+                 ":18.607171:99104.000000:0:0:0:0:1957472:1546:0:483672.000000:"
+                 "20488:0:0:0:151429:47022:NONE:defaultdepartment:NONE:1:0:50.7"
+                 "96277:4.497218:0.339940:-u prdatl26 -q grid.q -binding no_job"
+                 "_binding 0 0 0 0 no_explicit_binding:0.000000:NONE:5944487936"
+                 ".000000:0:0:NONE")
+
+        line4_values = {'JobName': "3294013",
+                        'LocalUserID': "prdatl26",
+                        'LocalUserGroup': "prdatl",
+                        'WallDuration': 359,
+                        'CpuDuration': 51,
+                        'StartTime': datetime.utcfromtimestamp(1404169049),
+                        'StopTime': datetime.utcfromtimestamp(1404169408),
+                        'MemoryReal': int(4.497218*1024*1024),
+                        'MemoryVirtual': 5944487936,
+                        'NodeCount': 0,
+                        'Processors': 1
+                        }
+
+        cases[line4] = line4_values
+
         for line in cases.keys():
             record = self.parser.parse(line)
             cont = record._record_content

--- a/test/test_sge.py
+++ b/test/test_sge.py
@@ -115,6 +115,43 @@ class ParserSGETest(unittest.TestCase):
             for key in cases[line].keys():
                 self.assertEqual(cont[key], cases[line][key], "%s != %s for key %s" % (cont[key], cases[line][key], key))
 
+    def test_univa_timestamps(self):
+        """
+        Univa Grid Engine timestamps changed from seconds to milliseconds in
+        version 8.2.0. This tests the new format accounting log.
+        """
+        self.parser.ms_timestamps = True
+
+        line = ("grid.q:node101.cm.cluster:atlas:atlas235:cream_814542935:38725"
+                "61:sge:0:1412932860657:1412932865141:1412933085629:0:0:220.488"
+                ":7.301:5.469:123796:0:0:0:0:601325:794:0:237152:728:0:0:0:5439"
+                "6:1217:NONE:defaultdepartment:NONE:1:0:12.770:0.803193:0.08415"
+                "9:-u atlas235 -q grid.q -binding no_job_binding 0 0 0 0 no_exp"
+                "licit_binding:0.000000:NONE:1291231232:0:0:NONE:NONE:124411904"
+                ":115065856:grid-cream-02.hpc.susx.ac.uk:NONE:qsub /tmp/cream_8"
+                "14542935")
+
+        values = {'JobName': "3872561",
+                  'LocalUserID': "atlas235",
+                  'LocalUserGroup': "atlas",
+                  'WallDuration': 220,
+                  'CpuDuration': 13,
+                  'StartTime': datetime.utcfromtimestamp(1412932865),
+                  'StopTime': datetime.utcfromtimestamp(1412933086),
+                  'MemoryReal': int(0.803193*1024*1024),
+                  'MemoryVirtual': 1291231232,
+                  'NodeCount': 0,
+                  'Processors': 1
+                  }
+
+        record = self.parser.parse(line)
+        cont = record._record_content
+
+        for key in values:
+            self.assertEqual(cont[key], values[key],
+                             "%s != %s for key %s" % (cont[key], values[key],
+                                                      key))
+
     def test_parse_line_with_multiplier(self):
         '''
         Multiplier (cpu, wall) functionality testing.

--- a/test/test_sge.py
+++ b/test/test_sge.py
@@ -120,7 +120,7 @@ class ParserSGETest(unittest.TestCase):
         Univa Grid Engine timestamps changed from seconds to milliseconds in
         version 8.2.0. This tests the new format accounting log.
         """
-        self.parser.ms_timestamps = True
+        self.parser._ms_timestamps = True
 
         line = ("grid.q:node101.cm.cluster:atlas:atlas235:cream_814542935:38725"
                 "61:sge:0:1412932860657:1412932865141:1412933085629:0:0:220.488"


### PR DESCRIPTION
Resolves #47.

- Add option to parser config that defines whether Grid Engine is using
  millisecond timestamps as Univa Grid Engine is doing this from version
  8.2.0. Will default to not converting the timestamp if the option is
  absent.
- Add unit test for this new timestamp format and unit test for changes to `parser.py`.
- Move call to datetime function in `apel/db/records/record.py` to its own `try...except` block as it needs
  different handling to the `int` call when raising a `ValueError`. In the former
  case, it is likely to be a timestamp out of range (possibly caused by the
  Grid Engine oddness) and having it masked by the error message of the `int` call was confusing.
- Make `test_record.py` directly runnable.