### PR TITLE
Log entries for saved and rejected messages

### DIFF
--- a/apel/db/loader/loader.py
+++ b/apel/db/loader/loader.py
@@ -149,19 +149,21 @@ class Loader(object):
                 self.load_msg(msg_text, signer)
                 
                 if self._save_msgs:
-                    self._acceptq.add({"body": msg_text,
-                                       "signer": signer,
-                                       "empaid": msg_id})
-                    
+                    name = self._acceptq.add({"body": msg_text,
+                                              "signer": signer,
+                                              "empaid": msg_id})
+                    log.info("Message saved to accpet queue as %s", name)
+
             except (RecordFactoryException, LoaderException,
                     InvalidRecordException, apel.db.ApelDbException,
                     XMLParserException, ExpatError), err:
                 errmsg = "Parsing unsuccessful: %s" % str(err)
                 log.warn('Message rejected. %s', errmsg)
-                self._rejectq.add({"body": msg_text,
-                                   "signer": signer,
-                                   "empaid": msg_id,
-                                   "error": errmsg})
+                name = self._rejectq.add({"body": msg_text,
+                                          "signer": signer,
+                                          "empaid": msg_id,
+                                          "error": errmsg})
+                log.info("Message saved to reject queue as %s", name)
 
             log.info("Removing message %s. ID = %s", self.current_msg, msg_id)
             self._inq.remove(self.current_msg)

--- a/apel/db/loader/loader.py
+++ b/apel/db/loader/loader.py
@@ -152,7 +152,7 @@ class Loader(object):
                     name = self._acceptq.add({"body": msg_text,
                                               "signer": signer,
                                               "empaid": msg_id})
-                    log.info("Message saved to accpet queue as %s", name)
+                    log.info("Message saved to accept queue as %s", name)
 
             except (RecordFactoryException, LoaderException,
                     InvalidRecordException, apel.db.ApelDbException,

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -50,6 +50,8 @@ class LoaderTest(unittest.TestCase):
 
         in_q = dirq.Queue(os.path.join(self.dir_path, 'incoming'),
                           schema=schema)
+        in_q.add({"body": "bad message", "signer": "test signer", "empaid": "",
+                  "error": ""})
         in_q.add({"body": "APEL-summary-job-message: v0.3",
                   "signer": "test signer", "empaid": "", "error": ""})
 

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -1,0 +1,38 @@
+import dirq
+import mock
+import os
+import shutil
+import tempfile
+import unittest
+
+import apel.db.loader
+
+
+schema = {"body": "string", "signer": "string",
+          "empaid": "string?", "error": "string?"}
+
+
+class LoaderTest(unittest.TestCase):
+
+    def setUp(self):
+        self.queue_path = tempfile.mkdtemp()
+        mock.patch('apel.db.ApelDb').start()
+        in_q = dirq.Queue(os.path.join(self.queue_path, 'incoming'),
+                          schema=schema)
+        in_q.add({"body": "test body", "signer": "test signer",
+                  "empaid": "", "error": ""})
+
+        self.loader = apel.db.loader.Loader(self.queue_path, False, 'mysql',
+                                            'host', 1234, 'db', 'user', 'pwd',
+                                            'somefile')
+
+    def test_basic_load_all(self):
+        """Check that load_all_msgs runs without problems."""
+        self.loader.load_all_msgs()
+
+    def tearDown(self):
+        shutil.rmtree(self.queue_path)
+        mock.patch.stopall()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -15,23 +15,50 @@ schema = {"body": "string", "signer": "string",
 class LoaderTest(unittest.TestCase):
 
     def setUp(self):
-        self.queue_path = tempfile.mkdtemp()
-        mock.patch('apel.db.ApelDb').start()
-        in_q = dirq.Queue(os.path.join(self.queue_path, 'incoming'),
+        # Create temporary directory for message queues and pidfiles
+        self.dir_path = tempfile.mkdtemp()
+
+        # Mock out the database as we're not testing that here
+        mock.patch('apel.db.ApelDb', autospec=True, spec_set=True).start()
+
+    def test_startup_fail(self):
+        """Check that startup fails due to extant pidfile."""
+        handle, extant_pid = tempfile.mkstemp()
+        os.close(handle)
+        loader = apel.db.loader.Loader(self.dir_path, False, 'mysql', 'host',
+                                       1234, 'db', 'user', 'pwd', extant_pid)
+        self.assertRaises(apel.db.loader.LoaderException, loader.startup)
+        os.remove(extant_pid)
+
+    def test_startup_shutdown(self):
+        """Check that pidfile is created on startup and removed on shutdown."""
+        pidfile = os.path.join(self.dir_path, 'pidfile')
+        loader = apel.db.loader.Loader(self.dir_path, False, 'mysql', 'host',
+                                       1234, 'db', 'user', 'pwd', pidfile)
+
+        loader.startup()
+        self.assertTrue(os.path.exists(pidfile))
+
+        loader.shutdown()
+        self.assertFalse(os.path.exists(pidfile))
+
+    def test_basic_load_all(self):
+        """Check that load_all_msgs runs without problems."""
+        pidfile = os.path.join(self.dir_path, 'pidfile')
+
+        in_q = dirq.Queue(os.path.join(self.dir_path, 'incoming'),
                           schema=schema)
         in_q.add({"body": "test body", "signer": "test signer",
                   "empaid": "", "error": ""})
 
-        self.loader = apel.db.loader.Loader(self.queue_path, False, 'mysql',
+        self.loader = apel.db.loader.Loader(self.dir_path, True, 'mysql',
                                             'host', 1234, 'db', 'user', 'pwd',
-                                            'somefile')
+                                            pidfile)
 
-    def test_basic_load_all(self):
-        """Check that load_all_msgs runs without problems."""
         self.loader.load_all_msgs()
 
     def tearDown(self):
-        shutil.rmtree(self.queue_path)
+        shutil.rmtree(self.dir_path)
         mock.patch.stopall()
 
 if __name__ == '__main__':

--- a/test/test_retrieve_dns.py
+++ b/test/test_retrieve_dns.py
@@ -70,6 +70,7 @@ class ConfigTestCase(unittest.TestCase):
             self.assertEqual(conf[key], settings[key],
                              "%s != %s for option %s" % (conf[key],
                                                          settings[key], key))
+        os.remove(path)
 
     def tearDown(self):
         # Stop all patchers so that they're reset for the next test


### PR DESCRIPTION
Resolves #67.

- Added a bit more info to the log output when messages are saved or rejected so that the queue location is added to the log.
- Added the first unittests for `loader.py`.
- Also added a missing `os.remove` to a different test.

