### PR TITLE
Change default for 'parallel' to true

### DIFF
--- a/conf/parser.cfg
+++ b/conf/parser.cfg
@@ -32,7 +32,7 @@ reparse = false
 # Valid types are LSF, PBS, SGE, SLURM
 type = 
 # Whether to try to parse multi-core details
-parallel = false
+parallel = true
 # Directory to search for accounting logfiles
 dir = 
 # Prefix shared by all log files to parse 


### PR DESCRIPTION
Resolves #68.

- Change default for 'parallel' to true in parser config so that new
  installations will default to parsing MPI data.