### PR TITLE
Sort log files to be processed

### DIFF
--- a/bin/parser.py
+++ b/bin/parser.py
@@ -153,7 +153,7 @@ def scan_dir(parser, dirpath, reparse, expr, apel_db, processed):
     try:
         log.info('Scanning directory: %s' % dirpath)
         
-        for item in os.listdir(dirpath):
+        for item in sorted(os.listdir(dirpath)):
             abs_file = os.path.join(dirpath, item)
             if os.path.isfile(abs_file) and expr.match(item):
                 # first, calculate the hash of the file:


### PR DESCRIPTION
Submitted in [this GGUS ticket](https://www.ggus.eu/index.php?mode=ticket_info&ticket_id=109162).

From commit message:

> It is much easier to skim over logs and search for some problems
> if you know that files are processed in some particular order.
> 
> Plain lexicographical sort is fine for all files that have YYYYMMDD
> as the non-constant part of the name: it coincides with sort by date
> that is the most natural thing.
> 
> Signed-off-by: AC

As I commented on the commit (see below), this is slower, but this step is only performed once per parser run and takes in the order of a couple of milliseconds, so I think this change is justified. 