### PR TITLE
HTCondor Parser

### DIFF
--- a/apel/parsers/htcondor.py
+++ b/apel/parsers/htcondor.py
@@ -1,5 +1,5 @@
 '''
-   Copyright (C) 2014 STFC
+   Copyright 2014 The Science and Technology Facilities Council
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15,13 +15,13 @@
 
    @author: Pavel Demin
 '''
-from apel.common import parse_time
+
+
+import logging
+
 from apel.db.records.event import EventRecord
 from apel.parsers import Parser
 
-import time
-import datetime
-import logging
 
 log = logging.getLogger(__name__)
 
@@ -67,4 +67,3 @@ class HTCondorParser(Parser):
         record = EventRecord()
         record.set_all(rc)
         return record
-

--- a/apel/parsers/htcondor.py
+++ b/apel/parsers/htcondor.py
@@ -49,13 +49,13 @@ class HTCondorParser(Parser):
                    'JobName'         : lambda x: x[0],
                    'LocalUserID'     : lambda x: x[1],
                    'LocalUserGroup'  : lambda x: "",
-                   'WallDuration'    : lambda x: x[2],
-                   'CpuDuration'     : lambda x: x[3]+x[4],
+                   'WallDuration'    : lambda x: int(x[2]),
+                   'CpuDuration'     : lambda x: int(x[3])+int(x[4]),
                    'StartTime'       : lambda x: x[5],
                    'StopTime'        : lambda x: x[6],
-                   'MemoryReal'      : lambda x: x[7],
-                   'MemoryVirtual'   : lambda x: x[8],
-                   'Processors'      : lambda x: x[9],
+                   'MemoryReal'      : lambda x: int(x[7]),
+                   'MemoryVirtual'   : lambda x: int(x[8]),
+                   'Processors'      : lambda x: int(x[9]),
                    'NodeCount'       : lambda x: 0
                   }
 

--- a/apel/parsers/htcondor.py
+++ b/apel/parsers/htcondor.py
@@ -1,0 +1,70 @@
+'''
+   Copyright (C) 2014 STFC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   @author: Pavel Demin
+'''
+from apel.common import parse_time
+from apel.db.records.event import EventRecord
+from apel.parsers import Parser
+
+import time
+import datetime
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class HTCondorParser(Parser):
+    '''
+    First implementation of the APEL parser for HTCondor
+    '''
+    def __init__(self, site, machine_name, mpi):
+        Parser.__init__(self, site, machine_name, mpi)
+        log.info('Site: %s; batch system: %s' % (self.site_name, self.machine_name))
+
+    def parse(self, line):
+        '''
+        Parses single line from accounting log file.
+        '''
+        # condor_history -constraint "JobStartDate > 0" -format "%d|" ClusterId -format "%s|" Owner -format "%d|" RemoteWallClockTime -format "%d|" RemoteUserCpu -format "%d|" RemoteSysCpu -format "%d|" JobStartDate -format "%d|" EnteredCurrentStatus -format "%d|" ResidentSetSize_RAW -format "%d|" ImageSize_RAW -format "%d\n" RequestCpus
+        # 1234567|opssgm|19|18|8|1412688273|1412708199|712944|2075028|1
+
+        values = line.strip().split('|')
+
+        mapping = {'Site'            : lambda x: self.site_name,
+                   'MachineName'     : lambda x: self.machine_name,
+                   'Infrastructure'  : lambda x: "APEL-CREAM-HTCONDOR",
+                   'JobName'         : lambda x: x[0],
+                   'LocalUserID'     : lambda x: x[1],
+                   'LocalUserGroup'  : lambda x: "",
+                   'WallDuration'    : lambda x: x[2],
+                   'CpuDuration'     : lambda x: x[3]+x[4],
+                   'StartTime'       : lambda x: x[5],
+                   'StopTime'        : lambda x: x[6],
+                   'MemoryReal'      : lambda x: x[7],
+                   'MemoryVirtual'   : lambda x: x[8],
+                   'Processors'      : lambda x: x[9],
+                   'NodeCount'       : lambda x: 0
+                  }
+
+        rc = {}
+
+        for key in mapping:
+            rc[key] = mapping[key](values)
+
+        record = EventRecord()
+        record.set_all(rc)
+        return record
+

--- a/apel/parsers/htcondor.py
+++ b/apel/parsers/htcondor.py
@@ -38,8 +38,8 @@ class HTCondorParser(Parser):
         '''
         Parses single line from accounting log file.
         '''
-        # condor_history -constraint "JobStartDate > 0" -format "%d|" ClusterId -format "%s|" Owner -format "%d|" RemoteWallClockTime -format "%d|" RemoteUserCpu -format "%d|" RemoteSysCpu -format "%d|" JobStartDate -format "%d|" EnteredCurrentStatus -format "%d|" ResidentSetSize_RAW -format "%d|" ImageSize_RAW -format "%d\n" RequestCpus
-        # 1234567|opssgm|19|18|8|1412688273|1412708199|712944|2075028|1
+        # condor_history -constraint "JobStartDate > 0" -format "%s|" GlobalJobId -format "%s|" Owner -format "%d|" RemoteWallClockTime -format "%d|" RemoteUserCpu -format "%d|" RemoteSysCpu -format "%d|" JobStartDate -format "%d|" EnteredCurrentStatus -format "%d|" ResidentSetSize_RAW -format "%d|" ImageSize_RAW  -format "%d|" RequestCpus  -format "%s\n" RequestCpus
+        # arcce.rl.ac.uk#2376.0#71589|tatls011|287|107|11|1435671643|1435671930|26636|26832|1|1
 
         values = line.strip().split('|')
 

--- a/apel/parsers/htcondor.py
+++ b/apel/parsers/htcondor.py
@@ -38,7 +38,7 @@ class HTCondorParser(Parser):
         '''
         Parses single line from accounting log file.
         '''
-        # condor_history -constraint "JobStartDate > 0" -format "%s|" GlobalJobId -format "%s|" Owner -format "%d|" RemoteWallClockTime -format "%d|" RemoteUserCpu -format "%d|" RemoteSysCpu -format "%d|" JobStartDate -format "%d|" EnteredCurrentStatus -format "%d|" ResidentSetSize_RAW -format "%d|" ImageSize_RAW  -format "%d|" RequestCpus  -format "%s\n" RequestCpus
+        # condor_history -constraint "JobStartDate > 0" -format "%s|" GlobalJobId -format "%s|" Owner -format "%d|" RemoteWallClockTime -format "%d|" RemoteUserCpu -format "%d|" RemoteSysCpu -format "%d|" JobStartDate -format "%d|" EnteredCurrentStatus -format "%d|" ResidentSetSize_RAW -format "%d|" ImageSize_RAW -format "%d|" RequestCpus
         # arcce.rl.ac.uk#2376.0#71589|tatls011|287|107|11|1435671643|1435671930|26636|26832|1|1
 
         values = line.strip().split('|')

--- a/apel/parsers/htcondor.py
+++ b/apel/parsers/htcondor.py
@@ -48,7 +48,7 @@ class HTCondorParser(Parser):
                    'Infrastructure'  : lambda x: "APEL-CREAM-HTCONDOR",
                    'JobName'         : lambda x: x[0],
                    'LocalUserID'     : lambda x: x[1],
-                   'LocalUserGroup'  : lambda x: x[10],
+                   'LocalUserGroup'  : lambda x: "",
                    'WallDuration'    : lambda x: int(x[2]),
                    'CpuDuration'     : lambda x: int(x[3])+int(x[4]),
                    'StartTime'       : lambda x: x[5],

--- a/apel/parsers/htcondor.py
+++ b/apel/parsers/htcondor.py
@@ -48,7 +48,7 @@ class HTCondorParser(Parser):
                    'Infrastructure'  : lambda x: "APEL-CREAM-HTCONDOR",
                    'JobName'         : lambda x: x[0],
                    'LocalUserID'     : lambda x: x[1],
-                   'LocalUserGroup'  : lambda x: "",
+                   'LocalUserGroup'  : lambda x: x[10],
                    'WallDuration'    : lambda x: int(x[2]),
                    'CpuDuration'     : lambda x: int(x[3])+int(x[4]),
                    'StartTime'       : lambda x: x[5],

--- a/bin/parser.py
+++ b/bin/parser.py
@@ -43,6 +43,7 @@ from apel.parsers.lsf import LSFParser
 from apel.parsers.sge import SGEParser
 from apel.parsers.pbs import PBSParser
 from apel.parsers.slurm import SlurmParser
+from apel.parsers.htcondor import HTCondorParser
 
 
 LOGGER_ID = 'parser'
@@ -55,8 +56,10 @@ PARSERS = {
            'LSF': LSFParser,
            'SGE': SGEParser,
            'SLURM': SlurmParser,
-           'blah' : BlahParser
+           'blah' : BlahParser,
+           'HTCondor': HTCondorParser,
            }
+
 
 class ParserConfigException(Exception):
     '''

--- a/conf/parser.cfg
+++ b/conf/parser.cfg
@@ -29,7 +29,7 @@ enabled = true
 reparse = false
 
 # Batch system specific options.
-# Valid types are LSF, PBS, SGE, SLURM
+# Valid types are LSF, PBS, SGE, SLURM, HTCondor
 type = 
 # Whether to try to parse multi-core details
 parallel = true

--- a/scripts/htcondor_acc.sh
+++ b/scripts/htcondor_acc.sh
@@ -1,0 +1,13 @@
+#! /bin/sh
+
+CONDOR_LOCATION=/home/condor/release
+OUTPUT_LOCATION=/scratch/condor/apel
+
+NOW=$(date +"%Y%m%dT%H%M%S")
+OUTPUT_FILE=$OUTPUT_LOCATION/accounting.$NOW
+
+$CONDOR_LOCATION/bin/condor_history -constraint "JobStartDate > 0" -format "%d|" ClusterId -format "%s|" Owner -format "%d|" RemoteWallClockTime -format "%d|" RemoteUserCpu -format "%d|" RemoteSysCpu -format "%d|" JobStartDate -format "%d|" EnteredCurrentStatus -format "%d|" ResidentSetSize_RAW -format "%d|" ImageSize_RAW -format "%d\n" RequestCpus > $OUTPUT_FILE
+
+/usr/bin/apelparser
+
+/bin/find $OUTPUT_LOCATION -name accounting.\* -mtime +30 -exec /bin/rm {} \;

--- a/scripts/htcondor_acc.sh
+++ b/scripts/htcondor_acc.sh
@@ -14,11 +14,6 @@ OUTPUT_FILE=$OUTPUT_LOCATION/accounting.$NOW
 # Build the filter for the history command
 CONSTR="(JobStartDate>0)&&(CompletionDate>`date +%s -d "01 Jan 2014"`)"
 
-# Only get the jobs submitted from this CE (ceCertificateSubject is
-# set in /etc/condor/config.s/blah and added to the job classad with
-# the SUBMIT_EXPRS directive in the same file)
-CONSTR=${CONSTR}"&&(ceCertificateSubject==$(condor_config_val ceCertificateSubject))"
-
 # Populate the temporary file
 for HF in $HISTORY_FILES
 do

--- a/scripts/htcondor_acc.sh
+++ b/scripts/htcondor_acc.sh
@@ -5,7 +5,7 @@ OUTPUT_LOCATION=/var/log/accounting
 
 # Find all the history files modified in the last two months
 # (there can be more than one, if the CE submits to several schedds)
-HISTORY_FILES=$(find /var/lib/condor/spool/ -name history\* -mtime -61)
+HISTORY_FILES=$(find /var/lib/condor/spool/ -name history\* -mtime -62)
 
 # Create a temporary accounting file name
 NOW=$(date +"%Y%m%dT%H%M%S")

--- a/scripts/htcondor_acc.sh
+++ b/scripts/htcondor_acc.sh
@@ -32,7 +32,7 @@ do
 done
 
 # Invoke the parser
-/usr/bin/apelparser
+/usr/bin/apelparser --config /etc/apel/parser.cfg
 
 # Cleanup
 /bin/find $OUTPUT_LOCATION -name accounting.\* -mtime +30 -exec /bin/rm {} \;

--- a/scripts/htcondor_acc.sh
+++ b/scripts/htcondor_acc.sh
@@ -1,13 +1,43 @@
 #! /bin/sh
 
-CONDOR_LOCATION=/home/condor/release
-OUTPUT_LOCATION=/scratch/condor/apel
+CONDOR_LOCATION=/usr
+OUTPUT_LOCATION=/var/log/accounting
 
+# Find all the history files modified in the last two months
+# (there can be more than one, if the CE submits to several schedds)
+HISTORY_FILES=$(find /var/lib/condor/spool/ -name history\* -mtime -61)
+
+# Create a temporary accounting file name
 NOW=$(date +"%Y%m%dT%H%M%S")
 OUTPUT_FILE=$OUTPUT_LOCATION/accounting.$NOW
 
-$CONDOR_LOCATION/bin/condor_history -constraint "JobStartDate > 0" -format "%d|" ClusterId -format "%s|" Owner -format "%d|" RemoteWallClockTime -format "%d|" RemoteUserCpu -format "%d|" RemoteSysCpu -format "%d|" JobStartDate -format "%d|" EnteredCurrentStatus -format "%d|" ResidentSetSize_RAW -format "%d|" ImageSize_RAW -format "%d\n" RequestCpus > $OUTPUT_FILE
+# Build the filter for the history command
+CONSTR="(JobStartDate>0)&&(CompletionDate>`date +%s -d "01 Jan 2014"`)"
 
+# Only get the jobs submitted from this CE (ceCertificateSubject is
+# set in /etc/condor/config.s/blah and added to the job classad with
+# the SUBMIT_EXPRS directive in the same file)
+CONSTR=${CONSTR}"&&(ceCertificateSubject==$(condor_config_val ceCertificateSubject))"
+
+# Populate the temporary file
+for HF in $HISTORY_FILES
+do
+  $CONDOR_LOCATION/bin/condor_history -file $HF -constraint $CONSTR \
+    -format "%s|" GlobalJobId \
+    -format "%s|" Owner \
+    -format "%d|" RemoteWallClockTime \
+    -format "%d|" RemoteUserCpu \
+    -format "%d|" RemoteSysCpu \
+    -format "%d|" JobStartDate \
+    -format "%d|" EnteredCurrentStatus \
+    -format "%d|" ResidentSetSize_RAW \
+    -format "%d|" ImageSize_RAW \
+    -format "%d|" RequestCpus \
+    -format "%s\n" Group >> $OUTPUT_FILE
+done
+
+# Invoke the parser
 /usr/bin/apelparser
 
+# Cleanup
 /bin/find $OUTPUT_LOCATION -name accounting.\* -mtime +30 -exec /bin/rm {} \;

--- a/scripts/htcondor_acc.sh
+++ b/scripts/htcondor_acc.sh
@@ -28,7 +28,7 @@ do
     -format "%d|" ResidentSetSize_RAW \
     -format "%d|" ImageSize_RAW \
     -format "%d|" RequestCpus \
-    -format "%s\n" Group >> $OUTPUT_FILE
+    -format "\n" EMPTY >> $OUTPUT_FILE
 done
 
 # Invoke the parser

--- a/test/test_htcondor_parser.py
+++ b/test/test_htcondor_parser.py
@@ -29,7 +29,7 @@ class HTCondorParserTest(unittest.TestCase):
         )
 
         values = (
-            ('1234567', 'opssgm', None, 19, 188,
+            ('1234567', 'opssgm', None, 19, 26,
              datetime.datetime(2014, 10, 7, 13, 24, 33),
              datetime.datetime(2014, 10, 7, 18, 56, 39),
              712944, 2075028, 0, 1),

--- a/test/test_htcondor_parser.py
+++ b/test/test_htcondor_parser.py
@@ -1,0 +1,59 @@
+import datetime
+import unittest
+
+from apel.parsers.htcondor import HTCondorParser
+
+
+class HTCondorParserTest(unittest.TestCase):
+    """
+    Test case for HTCondor parser
+    """
+
+    def setUp(self):
+        self.parser = HTCondorParser('testSite', 'testHost', True)
+
+    def test_parse_line(self):
+
+        keys = ('JobName', 'LocalUserID', 'LocalUserGroup', 'WallDuration',
+                'CpuDuration', 'StartTime', 'StopTime', 'MemoryReal',
+                'MemoryVirtual', 'NodeCount', 'Processors')
+
+        # condor_history output (line split):
+        #   ClusterId|Owner|RemoteWallClockTime|RemoteUserCpu|RemoteSysCpu|
+        #   JobStartDate|EnteredCurrentStatus|ResidentSetSize_RAW|ImageSize_RAW|
+        #   RequestCpus
+
+        # Examples for correct lines
+        lines = (
+            ('1234567|opssgm|19|18|8|1412688273|1412708199|712944|2075028|1'),
+        )
+
+        values = (
+            ('1234567', 'opssgm', None, 19, 188,
+             datetime.datetime(2014, 10, 7, 13, 24, 33),
+             datetime.datetime(2014, 10, 7, 18, 56, 39),
+             712944, 2075028, 0, 1),
+        )
+
+        cases = {}
+        for line, value in zip(lines, values):
+            cases[line] = dict(zip(keys, value))
+
+        for line in cases.keys():
+            record = self.parser.parse(line)
+            cont = record._record_content
+
+            self.assertEqual(cont['Site'], 'testSite')
+            self.assertEqual(cont['MachineName'], 'testHost')
+            self.assertEqual(cont['Infrastructure'], 'APEL-CREAM-HTCONDOR')
+
+            for key in cases[line].keys():
+                self.assertTrue(key in cont, "Key '%s' not in record." % key)
+
+            for key in cases[line].keys():
+                self.assertEqual(cont[key], cases[line][key],
+                                 "%s != %s for key %s." %
+                                 (cont[key], cases[line][key], key))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_htcondor_parser.py
+++ b/test/test_htcondor_parser.py
@@ -25,7 +25,10 @@ class HTCondorParserTest(unittest.TestCase):
 
         # Examples for correct lines
         lines = (
-            ('1234567|opssgm|19|18|8|1412688273|1412708199|712944|2075028|1'),
+            '1234567|opssgm|19|18|8|1412688273|1412708199|712944|2075028|1',
+            'arcce.rl.ac.uk#2376.0#1589|tatls011|287|107|11|1435671643|1435671930|26636|26832|1|1',
+            'arcce.rl.ac.uk#2486.0#1888|t2k016|4|0|0|1435671919|1435671922|0|11|1|1',
+            'arcce.rl.ac.uk#2478.0#1874|snoplus014|2|0|0|1435671918|1435671920|0|11|1|1',
         )
 
         values = (
@@ -33,6 +36,18 @@ class HTCondorParserTest(unittest.TestCase):
              datetime.datetime(2014, 10, 7, 13, 24, 33),
              datetime.datetime(2014, 10, 7, 18, 56, 39),
              712944, 2075028, 0, 1),
+            ('arcce.rl.ac.uk#2376.0#1589', 'tatls011', None, 287, 118,
+             datetime.datetime(2015, 6, 30, 13, 40, 43),
+             datetime.datetime(2015, 6, 30, 13, 45, 30),
+             26636, 26832, 0, 1),
+            ('arcce.rl.ac.uk#2486.0#1888', 't2k016', None, 4, 0,
+             datetime.datetime(2015, 6, 30, 13, 45, 19),
+             datetime.datetime(2015, 6, 30, 13, 45, 22),
+             0, 11, 0, 1),
+            ('arcce.rl.ac.uk#2478.0#1874', 'snoplus014', None, 2, 0,
+             datetime.datetime(2015, 6, 30, 13, 45, 18),
+             datetime.datetime(2015, 6, 30, 13, 45, 20),
+             0, 11, 0, 1),
         )
 
         cases = {}

--- a/test/test_htcondor_parser.py
+++ b/test/test_htcondor_parser.py
@@ -19,7 +19,7 @@ class HTCondorParserTest(unittest.TestCase):
                 'MemoryVirtual', 'NodeCount', 'Processors')
 
         # condor_history output (line split):
-        #   ClusterId|Owner|RemoteWallClockTime|RemoteUserCpu|RemoteSysCpu|
+        #   GlobalJobId|Owner|RemoteWallClockTime|RemoteUserCpu|RemoteSysCpu|
         #   JobStartDate|EnteredCurrentStatus|ResidentSetSize_RAW|ImageSize_RAW|
         #   RequestCpus
 

--- a/test/test_htcondor_parser.py
+++ b/test/test_htcondor_parser.py
@@ -55,5 +55,6 @@ class HTCondorParserTest(unittest.TestCase):
                                  "%s != %s for key %s." %
                                  (cont[key], cases[line][key], key))
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Resolves #43.

Adds a basic HTCondor parser to APEL.

It's a meld of Pavel's and David's submissions, though the site-specific aspects of David's have been removed. Sites can customise the parser if they want to add in more specific functionality.