### PR TITLE
ARC Parser

### DIFF
--- a/apel/common/datetime_utils.py
+++ b/apel/common/datetime_utils.py
@@ -47,10 +47,16 @@ def parse_timestamp(datetime_string):
     '''
     Parse timestamp encoded as a string in various forms.  Return
     a TZ-unaware datetime object, which is in UTC.
-    
+
     If timezone information is not present in the string, it
-    assumes that the timezone is UTC.  
+    assumes that the timezone is UTC.
     '''
+
+    # If format is YYYYMMDDhhmmssZ (no T) add time designator so it is strictly
+    # compliant with ISO 8601. (Some versions of iso8601 module are fussy.)
+    if re.match(r'[0-9]{14}Z', datetime_string) is not None:
+        datetime_string = datetime_string[:8] + 'T' + datetime_string[8:]
+
     dt = iso8601.parse_date(datetime_string)
     utcdt = dt.astimezone(iso8601.iso8601.UTC)
     # internal representation of datetimes is UTC without timezones

--- a/apel/parsers/arc.py
+++ b/apel/parsers/arc.py
@@ -3,7 +3,7 @@ from apel.db.records.job import JobRecord
 from apel.parsers import Parser
 
 
-class ArcParser(Parser):
+class ARCParser(Parser):
     """
     Parser for ARC accounting records.
 
@@ -12,7 +12,10 @@ class ArcParser(Parser):
     """
     def parse_arc_file(self, arcfile):
         """
-        Takes an open ARC accounting file object and returns a JobRecord.
+        Parse an ARC accounting file.
+
+        Takes an open ARC accounting file object and returns a JobRecord and the
+        number of lines in it.
         """
         arcjob = {}
         lines = 0
@@ -20,7 +23,12 @@ class ArcParser(Parser):
             lines += 1
             key, value = line.split('=', 1)
             arcjob[key] = value[:-1]  # remove trailing newline
-        arcjob['accounting_options'] = self.accounting_options2dict(arcjob['accounting_options'])
+
+        if arcjob == {}:
+            # Empty file so return None
+            return None, lines
+
+        arcjob['accounting_options'] = self.parse_accounting_options(arcjob['accounting_options'])
 
         apeljob = {}
         apeljob['Site'] = arcjob['accounting_options']['gocdb_name']
@@ -51,7 +59,7 @@ class ArcParser(Parser):
         record.set_all(apeljob)
         return record, lines
 
-    def accounting_options2dict(self, accounting_options):
+    def parse_accounting_options(self, accounting_options):
         options = {}
         for pair in accounting_options.split(','):
             key, value = pair.split(':')

--- a/apel/parsers/arc.py
+++ b/apel/parsers/arc.py
@@ -10,12 +10,14 @@ class ArcParser(Parser):
     This parser differs from most of the others as ARC saves each accounting
     record in a separate file.
     """
-    def parse_file(self, arcfile):
+    def parse_arc_file(self, arcfile):
         """
         Takes an open ARC accounting file object and returns a JobRecord.
         """
         arcjob = {}
+        lines = 0
         for line in arcfile:
+            lines += 1
             key, value = line.split('=', 1)
             arcjob[key] = value[:-1]  # remove trailing newline
         arcjob['accounting_options'] = self.accounting_options2dict(arcjob['accounting_options'])
@@ -47,7 +49,7 @@ class ArcParser(Parser):
 
         record = JobRecord()
         record.set_all(apeljob)
-        return record
+        return record, lines
 
     def accounting_options2dict(self, accounting_options):
         options = {}

--- a/apel/parsers/arc.py
+++ b/apel/parsers/arc.py
@@ -20,7 +20,8 @@ class ARCParser(Parser):
         arcjob = {}
         lines = 0
         for line in arcfile:
-            line = line.rstrip("\r\n")  # Remove any trailing newline characters
+            # Remove any leading or trailing whitespace including newlines.
+            line = line.strip()
             lines += 1
             key, value = line.split('=', 1)
             arcjob[key] = value

--- a/apel/parsers/arc.py
+++ b/apel/parsers/arc.py
@@ -20,9 +20,10 @@ class ARCParser(Parser):
         arcjob = {}
         lines = 0
         for line in arcfile:
+            line = line.rstrip("\r\n")  # Remove any trailing newline characters
             lines += 1
             key, value = line.split('=', 1)
-            arcjob[key] = value[:-1]  # remove trailing newline
+            arcjob[key] = value
 
         if arcjob == {}:
             # Empty file so return None

--- a/apel/parsers/arc.py
+++ b/apel/parsers/arc.py
@@ -16,6 +16,9 @@ class ARCParser(Parser):
 
         Takes an open ARC accounting file object and returns a JobRecord and the
         number of lines in it.
+
+        The ARC to APEL mapping used can be found in the JURA souce code here:
+        http://svn.nordugrid.org/trac/nordugrid/browser/arc1/trunk/src/services/a-rex/jura/arexlog2ur.txt
         """
         arcjob = {}
         lines = 0

--- a/apel/parsers/arc.py
+++ b/apel/parsers/arc.py
@@ -25,8 +25,8 @@ class ARCParser(Parser):
             key, value = line.split('=', 1)
             arcjob[key] = value
 
-        if arcjob == {}:
-            # Empty file so return None
+        if lines == 0 or 'status' not in arcjob or arcjob['status'] != "completed":
+            # Empty file, incomplete job, or failed job (respectively)
             return None, lines
 
         arcjob['accounting_options'] = self.parse_accounting_options(arcjob['accounting_options'])

--- a/apel/parsers/arc.py
+++ b/apel/parsers/arc.py
@@ -1,0 +1,57 @@
+from apel.common.datetime_utils import parse_timestamp
+from apel.db.records.job import JobRecord
+from apel.parsers import Parser
+
+
+class ArcParser(Parser):
+    """
+    Parser for ARC accounting records.
+
+    This parser differs from most of the others as ARC saves each accounting
+    record in a separate file.
+    """
+    def parse_file(self, arcfile):
+        """
+        Takes an open ARC accounting file object and returns a JobRecord.
+        """
+        arcjob = {}
+        for line in arcfile:
+            key, value = line.split('=', 1)
+            arcjob[key] = value[:-1]  # remove trailing newline
+        arcjob['accounting_options'] = self.accounting_options2dict(arcjob['accounting_options'])
+
+        apeljob = {}
+        apeljob['Site'] = arcjob['accounting_options']['gocdb_name']
+        apeljob['SubmitHost'] = arcjob['headnode']
+        apeljob['MachineName'] = ''
+        apeljob['Queue'] = arcjob['queue']
+        apeljob['LocalJobId'] = arcjob['localid']
+        apeljob['LocalUserId'] = arcjob['localuser']
+        apeljob['GlobalUserName'] = arcjob['usersn']
+        apeljob['FQAN'] = ''
+        apeljob['VO'] = ''
+        apeljob['VOGroup'] = ''
+        apeljob['VORole'] = ''
+        apeljob['WallDuration'] = arcjob['usedwalltime']
+        apeljob['CpuDuration'] = arcjob['usedcputime']
+        apeljob['Processors'] = arcjob['processors']
+        apeljob['NodeCount'] = arcjob['nodecount']
+        apeljob['StartTime'] = parse_timestamp(arcjob['submissiontime'])
+        apeljob['EndTime'] = parse_timestamp(arcjob['endtime'])
+        apeljob['InfrastructureDescription'] = ''.join(['APEL-ARC-', arcjob['lrms'].upper()])
+        apeljob['InfrastructureType'] = 'grid'
+        apeljob['MemoryReal'] = arcjob['usedmemory']
+        apeljob['MemoryVirtual'] = ''
+        apeljob['ServiceLevelType'] = arcjob['accounting_options']['benchmark_type']
+        apeljob['ServiceLevel'] = arcjob['accounting_options']['benchmark_value']
+
+        record = JobRecord()
+        record.set_all(apeljob)
+        return record
+
+    def accounting_options2dict(self, accounting_options):
+        options = {}
+        for pair in accounting_options.split(','):
+            key, value = pair.split(':')
+            options[key] = value
+        return options

--- a/bin/parser.py
+++ b/bin/parser.py
@@ -94,15 +94,17 @@ def parse_file(parser, apel_db, fp, replace):
     log = logging.getLogger(LOGGER_ID)
     records = []
 
+    line_number = 0
+    parsed = 0
+
     # ARC produces one multiline record per file so requires different handling
     if parser == ARCParser:
         try:
-            record, lines = parser.parse_arc_file(fp)
+            record, line_number = parser.parse_arc_file(fp)
         except Exception:
             log.warn('Failed to parse file.  Is %s correct?',
                      parser.__class__.__name__)
         else:
-            line_number = lines
             if record is not None:
                 records.append(record)
                 apel_db.load_records(records, replace=replace)
@@ -118,9 +120,7 @@ def parse_file(parser, apel_db, fp, replace):
         # how many times given error was raised
         exceptions = {}
 
-        line_number = 0
         index = 0
-        parsed = 0
         failed = 0
         ignored = 0
 

--- a/conf/parser.cfg
+++ b/conf/parser.cfg
@@ -29,7 +29,7 @@ enabled = true
 reparse = false
 
 # Batch system specific options.
-# Valid types are LSF, PBS, SGE, SLURM, HTCondor
+# Valid types are LSF, PBS, SGE, SLURM, HTCondor, ARC
 type = 
 # Whether to try to parse multi-core details
 parallel = true

--- a/test/test_arc.py
+++ b/test/test_arc.py
@@ -1,0 +1,53 @@
+import StringIO
+import unittest
+
+from apel.parsers.arc import ArcParser
+
+
+class ArcParserTest(unittest.TestCase):
+    def setUp(self):
+        self.parser = ArcParser('testSite', 'testHost', True)
+
+    def test_parse_file(self):
+        """
+        Test that the parser runs without raising an exception.
+        """
+        arcfile = StringIO.StringIO(data)
+        self.parser.parse_file(arcfile)
+
+        arcfile.close()
+
+
+data = """loggerurl=APEL:http://mq.cro-ngi.hr:6162
+accounting_options=urbatch:1000,archiving:/var/run/arc/urs,topic:/queue/global.accounting.cpu.central,gocdb_name:RAL-LCG2,use_ssl:true,Network:PROD,benchmark_type:Si2k,benchmark_value:1006.00
+key_path=/etc/grid-security/hostkey.pem
+certificate_path=/etc/grid-security/hostcert.pem
+ca_certificates_dir=/etc/grid-security/certificates
+description=&("savestate" = "yes" )("action" = "request" )("hostname" = "glidein.grid.iu.edu" )("executable" = "glidein_startup.sh" )("arguments" = "-v" "std" "-name" "gfactory_instance" "-entry" "CMS_T1_UK_RAL_arc_ce01" "-clientname" "CMSG-v1_0.t1prod" "-schedd" "schedd_glideins8@glidein.grid.iu.edu" "-proxy" "None" "-factory" "OSGGOC" "-web" "http://glidein.grid.iu.edu/factory/stage" "-sign" "95f5ff67925c4976de866257cbec03c2ef8cf735" "-signentry" "583d7f81aa05e0ee7c48e1c361aeea98b0d14307" "-signtype" "sha1" "-descript" "description.f5djRC.cfg" "-descriptentry" "description.f5djRC.cfg" "-dir" "TMPDIR" "-param_GLIDEIN_Client" "CMSG-v1_0.t1prod" "-submitcredid" "190564" "-slotslayout" "fixed" "-clientweb" "http://vocms080.cern.ch/vofrontend/stage" "-clientsign" "baf78ef8937facc5c909a88c12424ef391c92cf8" "-clientsigntype" "sha1" "-clientdescript" "description.f5bd1b.cfg" "-clientgroup" "t1prod" "-clientwebgroup" "http://vocms080.cern.ch/vofrontend/stage/group_t1prod" "-clientsigngroup" "fa57085cac8f9ef9b4b392164b55425d6e98755a" "-clientdescriptgroup" "description.f4kerW.cfg" "-param_CONDOR_VERSION" "8.dot,3.dot,2" "-param_GLIDEIN_Glexec_Use" "OPTIONAL" "-param_GLIDEIN_Job_Max_Time" "34800" "-param_GLIDECLIENT_ReqNode" "glidein.dot,grid.dot,iu.dot,edu" "-param_CONDOR_OS" "default" "-param_MIN_DISK_GBS" "1" "-param_GLIDEIN_Max_Idle" "2400" "-param_GLIDEIN_Monitoring_Enabled" "False" "-param_CONDOR_ARCH" "default" "-param_UPDATE_COLLECTOR_WITH_TCP" "True" "-param_USE_MATCH_AUTH" "True" "-param_GLIDEIN_Report_Failed" "NEVER" "-param_GLIDEIN_Collector" "vocms099.dot,cern.dot,ch.colon,9620.minus,10000.semicolon,vocms097.dot,cern.dot,ch.colon,9620.minus,10000" "-cluster" "2662132" "-subcluster" "9" )("executables" = "glidein_startup.sh" )("inputfiles" = (".gahp_complete" "" ) ("glidein_startup.sh" "" ) )("stdout" = "_condor_stdout.schedd_glideins8_glidein.grid.iu.edu_2662132.9_1432020406" )("stderr" = "_condor_stderr.schedd_glideins8_glidein.grid.iu.edu_2662132.9_1432020406" )("outputfiles" = ("_condor_stdout.schedd_glideins8_glidein.grid.iu.edu_2662132.9_1432020406" "" ) ("_condor_stderr.schedd_glideins8_glidein.grid.iu.edu_2662132.9_1432020406" "" ) )("memory" = "3050" )("runtimeenvironment" = "ENV/GLITE" )
+localuser=pcms024
+submissiontime=20150519072708Z
+ngjobid=WcyNDmp6qEmnCIXDjqiBL5XqABFKDmABFKDmdaGKDmJBFKDm2hQmpn
+usersn=/DC=ch/DC=cern/OU=computers/CN=cmspilot02/vocms080.cern.ch
+headnode=gsiftp://arc-ce01.gridpp.rl.ac.uk:2811/jobs
+lrms=condor
+queue=grid3000M
+localid=3710625.arc-ce01.gridpp.rl.ac.uk
+globalid=gsiftp://arc-ce01.gridpp.rl.ac.uk:2811/jobs/WcyNDmp6qEmnCIXDjqiBL5XqABFKDmABFKDmdaGKDmJBFKDm2hQmpn
+clienthost=129.79.53.27:54085
+usercert=-----BEGIN CERTIFICATE-----\ ___SNIP___ \-----END CERTIFICATE-----\
+requestedmemory=3050
+processors=1
+usedwalltime=47192
+usedusercputime=38047
+usedkernelcputime=2783
+usedmemory=1000000
+exitcode=0
+nodename=slot1@lcg1526.gridpp.rl.ac.uk
+nodecount=1
+usedcputime=40830
+endtime=20150519133100Z
+status=completed"""
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_arc.py
+++ b/test/test_arc.py
@@ -1,6 +1,7 @@
 import StringIO
 import unittest
 
+from apel.db.records.job import JobRecord
 from apel.parsers.arc import ArcParser
 
 
@@ -13,12 +14,15 @@ class ArcParserTest(unittest.TestCase):
         Test that the parser runs without raising an exception.
         """
         arcfile = StringIO.StringIO(data)
-        self.parser.parse_file(arcfile)
+        record, lines = self.parser.parse_arc_file(arcfile)
+        self.assertEqual(type(record), JobRecord)
+        self.assertEqual(lines, 29)
 
         arcfile.close()
 
 
-data = """loggerurl=APEL:http://mq.cro-ngi.hr:6162
+
+data = r"""loggerurl=APEL:http://mq.cro-ngi.hr:6162
 accounting_options=urbatch:1000,archiving:/var/run/arc/urs,topic:/queue/global.accounting.cpu.central,gocdb_name:RAL-LCG2,use_ssl:true,Network:PROD,benchmark_type:Si2k,benchmark_value:1006.00
 key_path=/etc/grid-security/hostkey.pem
 certificate_path=/etc/grid-security/hostcert.pem
@@ -46,7 +50,8 @@ nodename=slot1@lcg1526.gridpp.rl.ac.uk
 nodecount=1
 usedcputime=40830
 endtime=20150519133100Z
-status=completed"""
+status=completed
+"""
 
 
 if __name__ == '__main__':

--- a/test/test_arc.py
+++ b/test/test_arc.py
@@ -2,24 +2,36 @@ import StringIO
 import unittest
 
 from apel.db.records.job import JobRecord
-from apel.parsers.arc import ArcParser
+from apel.parsers.arc import ARCParser
 
 
-class ArcParserTest(unittest.TestCase):
+class ARCParserTest(unittest.TestCase):
     def setUp(self):
-        self.parser = ArcParser('testSite', 'testHost', True)
+        self.parser = ARCParser('testSite', 'testHost', True)
 
     def test_parse_file(self):
         """
-        Test that the parser runs without raising an exception.
+        Test that the parser returns a JobRecord and the right number of lines.
         """
         arcfile = StringIO.StringIO(data)
+
         record, lines = self.parser.parse_arc_file(arcfile)
         self.assertEqual(type(record), JobRecord)
         self.assertEqual(lines, 29)
 
         arcfile.close()
 
+    def test_parse_empty_file(self):
+        """
+        Test that the parser returns None when parsing an empty file.
+        """
+        empty_file = StringIO.StringIO("")
+
+        record, lines = self.parser.parse_arc_file(empty_file)
+        self.assertEqual(record, None)
+        self.assertEqual(lines, 0)
+
+        empty_file.close()
 
 
 data = r"""loggerurl=APEL:http://mq.cro-ngi.hr:6162

--- a/test/test_arc.py
+++ b/test/test_arc.py
@@ -13,7 +13,7 @@ class ARCParserTest(unittest.TestCase):
         """
         Test that the parser returns a JobRecord and the right number of lines.
         """
-        arcfile = StringIO.StringIO(data)
+        arcfile = StringIO.StringIO(complete)
 
         record, lines = self.parser.parse_arc_file(arcfile)
         self.assertEqual(type(record), JobRecord)
@@ -23,7 +23,7 @@ class ARCParserTest(unittest.TestCase):
 
     def test_parse_empty_file(self):
         """
-        Test that the parser returns None when parsing an empty file.
+        Test that the parser returns None and 0 for an empty file.
         """
         empty_file = StringIO.StringIO("")
 
@@ -33,8 +33,30 @@ class ARCParserTest(unittest.TestCase):
 
         empty_file.close()
 
+    def test_invalid_file(self):
+        """
+        Test that the parser raises an exception for an invalid file.
+        """
+        invalid_file = StringIO.StringIO("valid=line\ninvalid line")
 
-data = r"""loggerurl=APEL:http://mq.cro-ngi.hr:6162
+        self.assertRaises(ValueError, self.parser.parse_arc_file, invalid_file)
+
+        invalid_file.close()
+
+    def test_parse_incomplete_job(self):
+        """
+        Test that the parser returns None and >0 for an incomplete job.
+        """
+        incomplete_job = StringIO.StringIO(incomplete)
+
+        record, lines = self.parser.parse_arc_file(incomplete_job)
+        self.assertEqual(record, None)
+        self.assertNotEqual(lines, 0)
+
+        incomplete_job.close()
+
+
+complete = r"""loggerurl=APEL:http://mq.cro-ngi.hr:6162
 accounting_options=urbatch:1000,archiving:/var/run/arc/urs,topic:/queue/global.accounting.cpu.central,gocdb_name:RAL-LCG2,use_ssl:true,Network:PROD,benchmark_type:Si2k,benchmark_value:1006.00
 key_path=/etc/grid-security/hostkey.pem
 certificate_path=/etc/grid-security/hostcert.pem
@@ -63,6 +85,26 @@ nodecount=1
 usedcputime=40830
 endtime=20150519133100Z
 status=completed
+"""
+
+incomplete = r"""loggerurl=APEL:http://mq.cro-ngi.hr:6162
+accounting_options=urbatch:1000,archiving:/var/run/arc/urs,topic:/queue/global.accounting.cpu.central,gocdb_name:RAL-LCG2,use_ssl:true,Network:PROD,benchmark_type:Si2k,benchmark_value:1006.00
+key_path=/etc/grid-security/hostkey.pem
+certificate_path=/etc/grid-security/hostcert.pem
+ca_certificates_dir=/etc/grid-security/certificates
+description=&("savestate" = "yes" )("action" = "request" )("hostname" = "aipanda062.cern.ch" )("executable" = "runpilot3-wrapper.sh" )("arguments" = "-s" "ANALY_RAL_SL6" "-h" "ANALY_RAL_SL6" "-p" "25443" "-w" "https://pandaserver.cern.ch" "-u" "user" )("executables" = "runpilot3-wrapper.sh" )("inputfiles" = (".gahp_complete" "" ) ("runpilot3-wrapper.sh" "" ) )("stdout" = "_condor_stdout.aipanda062.cern.ch_5943946.21_1432043893" )("stderr" = "_condor_stderr.aipanda062.cern.ch_5943946.21_1432043893" )("outputfiles" = ("_condor_stdout.aipanda062.cern.ch_5943946.21_1432043893" "" ) ("_condor_stderr.aipanda062.cern.ch_5943946.21_1432043893" "" ) )("queue" = "grid3000M" )("runtimeenvironment" = "APPS/HEP/ATLAS-SITE-LCG" )("runtimeenvironment" = "ENV/PROXY" )("jobname" = "arc_pilot" )("memory" = "3000" )("walltime" = "345600" )("environment" = ("APFFID" "aipanda062-glexecdev" ) ("PANDA_JSID" "aipanda062-glexecdev" ) ("APFCID" "5943946.21" ) ("GTAG" "http://aipanda062.cern.ch/pilots/2015-05-19/ANALY_RAL_SL6-5495-dev/5943946.21.out" ) ("APFMON" "http://apfmon.lancs.ac.uk/api" ) ("FACTORYQUEUE" "ANALY_RAL_SL6-5495-dev" ) ("FACTORYUSER" "apf" ) ("RUCIO_ACCOUNT" "pilot" ) )
+localuser=tatls015
+submissiontime=20150519135824Z
+ngjobid=0JENDmUDxEmnCIXDjqiBL5XqABFKDmABFKDm5fVKDmMBFKDmT9YYQm
+usersn=/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=atlpilo1/CN=614260/CN=Robot: ATLAS Pilot1
+headnode=gsiftp://arc-ce01.gridpp.rl.ac.uk:2811/jobs
+lrms=condor
+queue=grid3000M
+jobname=arc_pilot
+globalid=gsiftp://arc-ce01.gridpp.rl.ac.uk:2811/jobs/0JENDmUDxEmnCIXDjqiBL5XqABFKDmABFKDm5fVKDmMBFKDmT9YYQm
+clienthost=128.142.200.45:56669
+requestedmemory=3000
+requestedwalltime=345600
 """
 
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -10,6 +10,7 @@ import unittest
 import mock
 
 import bin.parser
+from apel.parsers.arc import ARCParser
 
 
 class ParserTest(unittest.TestCase):
@@ -24,6 +25,13 @@ class ParserTest(unittest.TestCase):
     def test_parse_empty_file(self):
         """An empty file should be ignored and no errors raised."""
         bin.parser.parse_file(None, self.mock_db, self.tf, False)
+
+    def test_parse_empty_arc_file(self):
+        """An empty ARC file should be ignored and no errors raised."""
+        parsed, line_number = bin.parser.parse_file(ARCParser, self.mock_db,
+                                                    self.tf, False)
+        self.assertEqual(parsed, 0)
+        self.assertEqual(line_number, 0)
 
     def test_scan_dir(self):
         """


### PR DESCRIPTION
These changes add a basic ARC parser to APEL.

Note that ARC produces one accounting record per file, and that they contain enough information to produce a job record directly, so this influences where the ARC parser can fit in with our existing code without too many changes.

You may want to use [this link](https://github.com/apel/apel/compare/dev...tofu-rocketry:arc-parser?diff=unified&name=arc-parser&w=1) to view the diff with whitespace changes ignored. (Mainly for `bin/parser.py` which has a lot of the extant code indented into an `else:` block.)
