### PR TITLE
XML with no records crash fix

### DIFF
--- a/apel/db/loader/aur_parser.py
+++ b/apel/db/loader/aur_parser.py
@@ -17,7 +17,7 @@
 '''
 
 from apel.common import iso2seconds, parse_timestamp
-from xml_parser import XMLParser
+from xml_parser import XMLParser, XMLParserException
 from apel.db.records.normalised_summary import NormalisedSummaryRecord
 from apel.db.loader.car_parser import CarParser
 import logging
@@ -56,7 +56,7 @@ class AurParser(XMLParser):
         xml_storage_records = self.doc.getElementsByTagNameNS(self.NAMESPACE, 'SummaryRecord')
         
         if len(xml_storage_records) == 0:
-            raise Exception('File does not contain AUR records!') 
+            raise XMLParserException('File does not contain AUR records!')
         
         for xml_storage_record in xml_storage_records:
             record = self.parseAurRecord(xml_storage_record)

--- a/apel/db/loader/star_parser.py
+++ b/apel/db/loader/star_parser.py
@@ -49,10 +49,10 @@ class StarParser(XMLParser):
         records = []
         
         xml_storage_records = self.doc.getElementsByTagNameNS(self.NAMESPACE, 'StorageUsageRecord')
-        
+
         if len(xml_storage_records) == 0:
-            raise Exception('File does not contain car records!') 
-        
+            raise Exception('File does not contain StAR records!')
+
         for xml_storage_record in xml_storage_records:
             # get record and associated attributes
             record, group_attributes = self.parseStarRecord(xml_storage_record)

--- a/apel/db/loader/star_parser.py
+++ b/apel/db/loader/star_parser.py
@@ -22,7 +22,7 @@ import logging
 from apel.db.records.storage import StorageRecord
 from apel.db.records.group_attribute import GroupAttributeRecord
 from apel.common.datetime_utils import parse_timestamp
-from xml_parser import XMLParser
+from xml_parser import XMLParser, XMLParserException
 
 
 log = logging.getLogger(__name__)
@@ -51,7 +51,7 @@ class StarParser(XMLParser):
         xml_storage_records = self.doc.getElementsByTagNameNS(self.NAMESPACE, 'StorageUsageRecord')
 
         if len(xml_storage_records) == 0:
-            raise Exception('File does not contain StAR records!')
+            raise XMLParserException('File does not contain StAR records!')
 
         for xml_storage_record in xml_storage_records:
             # get record and associated attributes

--- a/test/test_star_parser.py
+++ b/test/test_star_parser.py
@@ -2,6 +2,8 @@ from datetime import datetime
 import unittest
 
 from apel.db.loader import StarParser
+from apel.db.loader.xml_parser import XMLParserException
+
 from test_car_parser import datetimes_equal
 
 
@@ -120,6 +122,14 @@ class StarParserTest(unittest.TestCase):
                         self.fail("Datetimes don't match for key %s: %s, %s" % (key, cont[key], self.cases[star][key]))
                 else:
                     self.assertEqual(cont[key], self.cases[star][key], "%s != %s for key %s" % (cont[key], self.cases[star][key], key))
+
+    def test_empty_xml(self):
+        """
+        Check that correct exception is raised for an XML file with no records.
+        """
+        parser = StarParser("<something></something>")
+        self.assertRaises(XMLParserException, parser.get_records)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Resolves #85.

- Change reference to CAR records to StAR records for exception message in
  StAR record parser-loader.
- Change exception from plain `Exception` to `XMLParserException` for StAR and
  AUR parser-loaders (to make sure it's consistent) as the plain `Exception` would not be caught by the
  loader. CAR parser already uses the [right exception](https://github.com/apel/apel/blob/dev/apel/db/loader/car_parser.py#L48).
- Add corresponding unit test for StAR parser-loader.