### PR TITLE
Remove args from create in logrotate script

### DIFF
--- a/scripts/apel-client
+++ b/scripts/apel-client
@@ -3,5 +3,5 @@
     weekly
     rotate 4
     missingok
-    create 640 apel apel
+    create
 }


### PR DESCRIPTION
Resolves #97.

Remove the file attribute arguments from the create directive in the logrotate script as there isn't necessarily an apel user on the system. Without the file attributes defined, the create directive defaults to using the same values as for the original log file.

See description for `create mode owner group` in the [logrotate man page](http://www.linuxcommand.org/man_pages/logrotate8.html).