### PR TITLE
Update Python versions in Travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,10 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.4"
+  - "3.5"
 matrix:
   allow_failures:
-    - python: "2.7"
-    - python: "3.4"
+    - python: "3.5"
   fast_finish: true
 
 # Route build to container-based infrastructure


### PR DESCRIPTION
- Remove Python 2.7 from allowed failures as we should now be building for
  OSes that have it as default.
- Update Python 3.4 to 3.5 as we can just check the latest available (could check all versions of 3.x, but that's overkill for a version that doesn't work for us at the moment).