### PR TITLE
Disable duplicate sites check in summariser

### DIFF
--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -83,7 +83,8 @@ def runprocess(db_config_file, config_file, log_config_file):
         # This is all the summarising logic, contained in ApelMysqlDb() and the stored procedures.
         if db_type == 'cpu':
             # Make sure that records are not coming from the same site by two different routes
-            db.check_duplicate_sites()
+            # N.B. Disabled as check doesn't scale well and isn't that useful.
+            # db.check_duplicate_sites()
             db.summarise_jobs()
             db.normalise_summaries()
             db.copy_summaries()


### PR DESCRIPTION
Resolves #104.

- Disable duplicate sites check in summariser as it doesn't scale well and
  it isn't that useful as it completely stops the summarising process if
  it detects a site sending both job records and summaries.

This should perhaps be replaced with more useful checks later, but it's not worth the effort at the moment considering it has been disable on production machine for ages.