### PR TITLE
Add support for GOCDB paging

### DIFF
--- a/bin/retrieve_dns.py
+++ b/bin/retrieve_dns.py
@@ -134,7 +134,7 @@ def dns_from_dom(dom):
     """
     Given a Document Object Model, get the content of all <HOSTDN> tags.
 
-    Returned as a list of strings.
+    Returns a list of strings.
     """
     dn_nodes = dom.getElementsByTagName('HOSTDN')
     
@@ -169,7 +169,7 @@ def dns_from_file(path):
 
 def next_link_from_dom(dom):
     """
-    Given a Document Object Model, return the "next" link if any, or None.
+    Given a Document Object Model, return the "next" link, if any, or None.
 
     i.e. the href of the <link rel="next" href="..."/> tag.
     """

--- a/bin/retrieve_dns.py
+++ b/bin/retrieve_dns.py
@@ -130,12 +130,12 @@ def get_xml(url, proxy):
     return dn_xml
     
 
-def dns_from_xml(xml_string):
-    '''
-    Given XML in string format, get the content of all <HOSTDN> tags as 
-    a list of strings.
-    '''
-    dom = xml.dom.minidom.parseString(xml_string)
+def dns_from_dom(dom):
+    """
+    Given a Document Object Model, get the content of all <HOSTDN> tags.
+
+    Returned as a list of strings.
+    """
     dn_nodes = dom.getElementsByTagName('HOSTDN')
     
     log.info('Found ' + str(len(dn_nodes)) + ' HOSTDN tags.' )
@@ -167,13 +167,14 @@ def dns_from_file(path):
     return dns
 
 
-def next_link_from_xml(xml_string):
-    """Return the href of the <link rel="next" href="..."/> tag, if any."""
+def next_link_from_dom(dom):
+    """
+    Given a Document Object Model, return the "next" link if any, or None.
+
+    i.e. the href of the <link rel="next" href="..."/> tag.
+    """
     # First, assume there is no next link
     next_url = None
-
-    # Parse the XML into a Document Object Model
-    dom = xml.dom.minidom.parseString(xml_string)
 
     # Get the link nodes from the DOM
     link_nodes = dom.getElementsByTagName('link')
@@ -233,10 +234,12 @@ def runprocess(config_file, log_config_file):
             log.info("Fetched XML from %s", next_url)
 
             try:
+                # Parse the XML into a Document Object Model
+                dom = xml.dom.minidom.parseString(xml_string)
                 # Get the next url, if any
-                next_url = next_link_from_xml(xml_string)
+                next_url = next_link_from_dom(dom)
                 # Add the listed DNs to the list
-                dns.extend(dns_from_xml(xml_string))
+                dns.extend(dns_from_dom(dom))
             except xml.parsers.expat.ExpatError, e:
                 log.warn('Failed to parse the retrieved XML.')
                 log.warn('Is the URL correct?')

--- a/bin/retrieve_dns.py
+++ b/bin/retrieve_dns.py
@@ -239,7 +239,7 @@ def runprocess(config_file, log_config_file):
                 dns.extend(dns_from_xml(xml_string))
             except xml.parsers.expat.ExpatError, e:
                 log.warn('Failed to parse the retrieved XML.')
-                loh.warn('Is the URL correct?')
+                log.warn('Is the URL correct?')
                 fetch_failed = True
     except AttributeError:
         # gocdb_url == None

--- a/test/test_retrieve_dns.py
+++ b/test/test_retrieve_dns.py
@@ -125,7 +125,7 @@ class RunprocessTestCase(unittest.TestCase):
 
         # Parse the test XML into a Document Object Model
         dom = xml.dom.minidom.parseString(xml_test_string)
-        
+
         result = bin.retrieve_dns.next_link_from_dom(dom)
         self.assertTrue(result, "next link")
 

--- a/test/test_retrieve_dns.py
+++ b/test/test_retrieve_dns.py
@@ -106,6 +106,7 @@ class RunprocessTestCase(unittest.TestCase):
         c.extra_dns = self.files['extra']['path']
         c.banned_dns = self.files['ban']['path']
         c.expire_hours = 1
+        c.gocdb_url = "not.a.host"
         mock_config.return_value = c
 
     def test_basics(self):

--- a/test/test_retrieve_dns.py
+++ b/test/test_retrieve_dns.py
@@ -1,8 +1,8 @@
 import os
 import tempfile
 import unittest
-
 import mock
+import xml.dom.minidom
 
 import bin.retrieve_dns
 
@@ -109,7 +109,7 @@ class RunprocessTestCase(unittest.TestCase):
         c.gocdb_url = "not.a.host"
         mock_config.return_value = c
 
-    def test_next_link_from_xml(self):
+    def test_next_link_from_dom(self):
         """Test a next link is correctly retrieved from a xml string."""
         xml_test_string = """<results>
         <meta>
@@ -123,7 +123,10 @@ class RunprocessTestCase(unittest.TestCase):
         <SERVICE_ENDPOINT><HOSTDN>invalid</HOSTDN></SERVICE_ENDPOINT>
         </results>"""
 
-        result = bin.retrieve_dns.next_link_from_xml(xml_test_string)
+        # Parse the test XML into a Document Object Model
+        dom = xml.dom.minidom.parseString(xml_test_string)
+        
+        result = bin.retrieve_dns.next_link_from_dom(dom)
         self.assertTrue(result, "next link")
 
     def test_basics(self):

--- a/test/test_retrieve_dns.py
+++ b/test/test_retrieve_dns.py
@@ -127,7 +127,7 @@ class RunprocessTestCase(unittest.TestCase):
         dom = xml.dom.minidom.parseString(xml_test_string)
 
         result = bin.retrieve_dns.next_link_from_dom(dom)
-        self.assertTrue(result, "next link")
+        self.assertEqual(result, "next link")
 
     def test_basics(self):
         self.mock_xml.return_value = """<results>

--- a/test/test_retrieve_dns.py
+++ b/test/test_retrieve_dns.py
@@ -109,6 +109,23 @@ class RunprocessTestCase(unittest.TestCase):
         c.gocdb_url = "not.a.host"
         mock_config.return_value = c
 
+    def test_next_link_from_xml(self):
+        """Test a next link is correctly retrieved from a xml string."""
+        xml_test_string = """<results>
+        <meta>
+        <link rel="self" href="not a next link"/>
+        <link rel="prev" href="not this one either"/>
+        <link rel="start" href="nor this one"/>
+        <link rel="next" href="next link"/>
+        </meta>
+        <SERVICE_ENDPOINT><HOSTDN>/basic/dn</HOSTDN></SERVICE_ENDPOINT>
+        <SERVICE_ENDPOINT><HOSTDN>/banned/dn</HOSTDN></SERVICE_ENDPOINT>
+        <SERVICE_ENDPOINT><HOSTDN>invalid</HOSTDN></SERVICE_ENDPOINT>
+        </results>"""
+
+        result = bin.retrieve_dns.next_link_from_xml(xml_test_string)
+        self.assertTrue(result, "next link")
+
     def test_basics(self):
         self.mock_xml.return_value = """<results>
         <SERVICE_ENDPOINT><HOSTDN>/basic/dn</HOSTDN></SERVICE_ENDPOINT>


### PR DESCRIPTION
- Adds method to retrieve the `next` link from fetched XML (or `None` if at last page or paging not in use)
- Adds test case for this method
- Moves `get_xml()` into a while loop, which ends when the `next` link is `None`
- Adds a mock `gocdb_url` for the `test_basics()` test case, as this now needs to be set, otherwise the while loop ends immediately, without fetching XML
- Passes Document Object Model (DOM) between methods to prevent parsing the same XML twice. 
- Renames `dns_from_xml` to `dns_from_dom` accordingly.