### PR TITLE
Cloud 0.4

### DIFF
--- a/apel.spec
+++ b/apel.spec
@@ -109,6 +109,8 @@ cp schemas/server-extra.sql %{buildroot}%_datadir/apel/
 cp schemas/cloud.sql %{buildroot}%_datadir/apel/
 cp schemas/storage.sql %{buildroot}%_datadir/apel/
 
+cp scripts/update_schema.sql %{buildroot}%_datadir/apel/
+
 # accounting scripts
 cp scripts/slurm_acc.sh %{buildroot}%_datadir/apel/
 cp scripts/htcondor_acc.sh %{buildroot}%_datadir/apel/
@@ -169,6 +171,7 @@ exit 0
 %_datadir/apel/server-extra.sql
 %_datadir/apel/cloud.sql
 %_datadir/apel/storage.sql
+%_datadir/apel/update_schema.sql
 # Use wildcard to match .py, .pyc, and .pyo
 %attr(755,root,root) %_datadir/apel/msg_status.py*
 

--- a/apel/db/__init__.py
+++ b/apel/db/__init__.py
@@ -19,7 +19,7 @@ JOB_MSG_HEADER = "APEL-individual-job-message: v0.3"
 SUMMARY_MSG_HEADER = "APEL-summary-job-message: v0.2"
 NORMALISED_SUMMARY_MSG_HEADER = "APEL-summary-job-message: v0.3"
 SYNC_MSG_HEADER = "APEL-sync-message: v0.1"
-CLOUD_MSG_HEADER = 'APEL-cloud-message: v0.2'
+CLOUD_MSG_HEADER = 'APEL-cloud-message: v0.4'
 CLOUD_SUMMARY_MSG_HEADER = 'APEL-cloud-summary-message: v0.2'
 
 from apel.db.apeldb import ApelDb, Query, ApelDbException

--- a/apel/db/__init__.py
+++ b/apel/db/__init__.py
@@ -20,6 +20,6 @@ SUMMARY_MSG_HEADER = "APEL-summary-job-message: v0.2"
 NORMALISED_SUMMARY_MSG_HEADER = "APEL-summary-job-message: v0.3"
 SYNC_MSG_HEADER = "APEL-sync-message: v0.1"
 CLOUD_MSG_HEADER = 'APEL-cloud-message: v0.4'
-CLOUD_SUMMARY_MSG_HEADER = 'APEL-cloud-summary-message: v0.2'
+CLOUD_SUMMARY_MSG_HEADER = 'APEL-cloud-summary-message: v0.4'
 
 from apel.db.apeldb import ApelDb, Query, ApelDbException

--- a/apel/db/backends/mysql.py
+++ b/apel/db/backends/mysql.py
@@ -68,8 +68,8 @@ class ApelMysqlDb(object):
               NormalisedSummaryRecord: "CALL ReplaceNormalisedSummary(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
               SyncRecord  : "CALL ReplaceSyncRecord(%s, %s, %s, %s, %s, %s)",
               ProcessedRecord : "CALL ReplaceProcessedFile(%s, %s, %s, %s, %s)",
-              CloudRecord : "CALL ReplaceCloudRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
-              CloudSummaryRecord : "CALL ReplaceCloudSummaryRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+              CloudRecord : "CALL ReplaceCloudRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+              CloudSummaryRecord : "CALL ReplaceCloudSummaryRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
               StorageRecord: "CALL ReplaceStarRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
               GroupAttributeRecord: "CALL ReplaceGroupAttribute(%s, %s, %s)"
               }

--- a/apel/db/backends/mysql.py
+++ b/apel/db/backends/mysql.py
@@ -69,7 +69,7 @@ class ApelMysqlDb(object):
               SyncRecord  : "CALL ReplaceSyncRecord(%s, %s, %s, %s, %s, %s)",
               ProcessedRecord : "CALL ReplaceProcessedFile(%s, %s, %s, %s, %s)",
               CloudRecord : "CALL ReplaceCloudRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
-              CloudSummaryRecord : "CALL ReplaceCloudSummaryRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+              CloudSummaryRecord : "CALL ReplaceCloudSummaryRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
               StorageRecord: "CALL ReplaceStarRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
               GroupAttributeRecord: "CALL ReplaceGroupAttribute(%s, %s, %s)"
               }

--- a/apel/db/records/cloud.py
+++ b/apel/db/records/cloud.py
@@ -38,24 +38,23 @@ class CloudRecord(Record):
         self._mandatory_fields = ["VMUUID", "SiteName"]
             
         # This list allows us to specify the order of lines when we construct records.
-        self._msg_fields  = ["VMUUID", "SiteName", "MachineName", 
+        self._msg_fields  = ["VMUUID", "SiteName", "CloudComputeService", "MachineName", 
                              "LocalUserId", "LocalGroupId", "GlobalUserName", "FQAN",
                              "Status", "StartTime", "EndTime", "SuspendDuration", 
                               "WallDuration",
                              "CpuDuration", "CpuCount", "NetworkType", "NetworkInbound", 
-                             "NetworkOutbound",
-                             "Memory", "Disk", "StorageRecordId", "ImageId", "CloudType"]
+                             "NetworkOutbound", "PublicIPCount", "Memory", "Disk", 
+                             "BenchmarkType", "Benchmark", "StorageRecordId", "ImageId", "CloudType"]
         
         # This list specifies the information that goes in the database.
-        self._db_fields = self._msg_fields[:7] + ['VO', 'VOGroup', 'VORole'] + self._msg_fields[7:]
+        self._db_fields = self._msg_fields[:8] + ['VO', 'VOGroup', 'VORole'] + self._msg_fields[8:]
         self._all_fields = self._db_fields
         
         self._ignored_fields = ["UpdateTime"]
         
         # Fields which will have an integer stored in them
         self._int_fields = [ "SuspendDuration", "WallDuration", "CpuDuration", "CpuCount", 
-                            "NetworkInbound", 
-                            "NetworkOutbound", "Memory", "Disk"]
+                            "NetworkInbound", "NetworkOutbound", "PublicIPCount", "Memory", "Disk"]
         
         self._datetime_fields = ["StartTime", "EndTime"]
     

--- a/apel/db/records/cloud.py
+++ b/apel/db/records/cloud.py
@@ -41,10 +41,10 @@ class CloudRecord(Record):
         self._msg_fields  = ["VMUUID", "SiteName", "CloudComputeService", "MachineName", 
                              "LocalUserId", "LocalGroupId", "GlobalUserName", "FQAN",
                              "Status", "StartTime", "EndTime", "SuspendDuration", 
-                              "WallDuration",
-                             "CpuDuration", "CpuCount", "NetworkType", "NetworkInbound", 
-                             "NetworkOutbound", "PublicIPCount", "Memory", "Disk", 
-                             "BenchmarkType", "Benchmark", "StorageRecordId", "ImageId", "CloudType"]
+                             "WallDuration", "CpuDuration", "CpuCount", 
+                             "NetworkType", "NetworkInbound", "NetworkOutbound", "PublicIPCount", 
+                             "Memory", "Disk", "BenchmarkType", "Benchmark", 
+                             "StorageRecordId", "ImageId", "CloudType"]
         
         # This list specifies the information that goes in the database.
         self._db_fields = self._msg_fields[:8] + ['VO', 'VOGroup', 'VORole'] + self._msg_fields[8:]
@@ -54,8 +54,9 @@ class CloudRecord(Record):
         
         # Fields which will have an integer stored in them
         self._int_fields = [ "SuspendDuration", "WallDuration", "CpuDuration", "CpuCount", 
-                            "NetworkInbound", "NetworkOutbound", "PublicIPCount", "Memory", "Disk"]
+                             "NetworkInbound", "NetworkOutbound", "PublicIPCount", "Memory", "Disk"]
         
+        self._float_fields = ['Benchmark']
         self._datetime_fields = ["StartTime", "EndTime"]
     
     def _check_fields(self):

--- a/apel/db/records/cloud_summary.py
+++ b/apel/db/records/cloud_summary.py
@@ -39,7 +39,7 @@ class CloudSummaryRecord(Record):
                              'GlobalUserName', 'VO', 'VOGroup', 'VORole',
                              'Status', 'CloudType', 'ImageId', 'EarliestStartTime', 
                              'LatestStartTime', 'WallDuration', 'CpuDuration', 'NetworkInbound', 
-                             'NetworkOutbound', 'PublicIPCount', 'Memory', 'Disk', 
+                             'NetworkOutbound', 'Memory', 'Disk', 
                              'BenchmarkType', 'Benchmark', 'NumberOfVMs']
         
         # This list specifies the information that goes in the database.
@@ -50,7 +50,7 @@ class CloudSummaryRecord(Record):
         
         # Fields which will have an integer stored in them
         self._int_fields = [ 'Month', 'Year', 'WallDuration', 'CpuDuration', 
-                             'NetworkInbound', 'NetworkOutbound', 'PublicIPCount',
+                             'NetworkInbound', 'NetworkOutbound',
                              'Memory', 'Disk', 'NumberOfVMs']
         
         self._float_fields = ['Benchmark']

--- a/apel/db/records/cloud_summary.py
+++ b/apel/db/records/cloud_summary.py
@@ -35,11 +35,12 @@ class CloudSummaryRecord(Record):
         self._mandatory_fields = ['SiteName', 'Month', 'Year', 'NumberOfVMs']
             
         # This list allows us to specify the order of lines when we construct records.
-        self._msg_fields  = ['SiteName', 'Month', 'Year', 
+        self._msg_fields  = ['SiteName', 'CloudComputeService', 'Month', 'Year', 
                              'GlobalUserName', 'VO', 'VOGroup', 'VORole',
                              'Status', 'CloudType', 'ImageId', 'EarliestStartTime', 
                              'LatestStartTime', 'WallDuration', 'CpuDuration', 'NetworkInbound', 
-                             'NetworkOutbound', 'Memory', 'Disk', 'NumberOfVMs']
+                             'NetworkOutbound', 'PublicIPCount', 'Memory', 'Disk', 
+                             'BenchmarkType', 'Benchmark', 'NumberOfVMs']
         
         # This list specifies the information that goes in the database.
         self._db_fields = self._msg_fields
@@ -49,9 +50,10 @@ class CloudSummaryRecord(Record):
         
         # Fields which will have an integer stored in them
         self._int_fields = [ 'Month', 'Year', 'WallDuration', 'CpuDuration', 
-                            'NetworkInbound', 'NetworkOutbound', 'Memory', 'Disk',
-                             'NumberOfVMs']
+                             'NetworkInbound', 'NetworkOutbound', 'PublicIPCount',
+                             'Memory', 'Disk', 'NumberOfVMs']
         
+        self._float_fields = ['Benchmark']
         self._datetime_fields = ['EarliestStartTime', 'LatestStartTime']
     
         

--- a/schemas/cloud.sql
+++ b/schemas/cloud.sql
@@ -32,6 +32,7 @@ CREATE TABLE CloudRecords (
   NetworkType VARCHAR(255),
   NetworkInbound INT, 
   NetworkOutbound INT, 
+  PublicIPCount INT,
   Memory INT, 
   Disk INT, 
 
@@ -64,19 +65,19 @@ CREATE PROCEDURE ReplaceCloudRecord(
   suspendDuration INT,
   wallDuration INT, cpuDuration INT, 
   cpuCount INT, networkType VARCHAR(255),  networkInbound INT, 
-  networkOutbound INT, memory INT, 
+  networkOutbound INT, publicIPCount INT, memory INT, 
   disk INT, storageRecordId VARCHAR(255),
   imageId VARCHAR(255), cloudType VARCHAR(255),
   publisherDN VARCHAR(255))
 BEGIN
     REPLACE INTO CloudRecords(VMUUID, SiteID, CloudComputeServiceID, MachineName, LocalUserId, LocalGroupId,
         GlobalUserNameID, FQAN, VOID, VOGroupID, VORoleID, Status, StartTime, EndTime, SuspendDuration,
-        WallDuration, CpuDuration, CpuCount, NetworkType, NetworkInbound, NetworkOutbound, Memory, Disk, StorageRecordId, ImageId, CloudType, PublisherDNID)
+        WallDuration, CpuDuration, CpuCount, NetworkType, NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, StorageRecordId, ImageId, CloudType, PublisherDNID)
       VALUES (
         VMUUID, SiteLookup(site), CloudComputeServiceLookup(cloudComputeService), machineName, localUserId, localGroupId, DNLookup(globalUserName), 
         fqan, VOLookup(vo),
         VOGroupLookup(voGroup), VORoleLookup(voRole), status, startTime, endTime, suspendDuration, 
-        wallDuration, cpuDuration, cpuCount, networkType, networkInbound, networkOutbound, memory,
+        wallDuration, cpuDuration, cpuCount, networkType, networkInbound, networkOutbound, publicIPCount, memory,
         disk, storageRecordId, imageId, cloudType, DNLookup(publisherDN)
         );
 END //
@@ -112,6 +113,7 @@ CREATE TABLE CloudSummaries (
 
   NetworkInbound BIGINT,
   NetworkOutbound BIGINT,
+  PublicIPCount BIGINT,
   Memory BIGINT,
   Disk BIGINT,
  
@@ -131,16 +133,16 @@ CREATE PROCEDURE ReplaceCloudSummaryRecord(
   cloudType VARCHAR(255), imageId VARCHAR(255), 
   earliestStartTime DATETIME, latestStartTime DATETIME, 
   wallDuration BIGINT, cpuDuration BIGINT, 
-  networkInbound BIGINT, networkOutbound BIGINT, memory BIGINT, 
+  networkInbound BIGINT, networkOutbound BIGINT, publicIPCount BIGINT, memory BIGINT, 
   disk BIGINT, numberOfVMs BIGINT,
   publisherDN VARCHAR(255))
 BEGIN
     REPLACE INTO CloudSummaries(SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId, EarliestStartTime, LatestStartTime, 
-        WallDuration, CpuDuration, NetworkInbound, NetworkOutbound, Memory, Disk, NumberOfVMs,  PublisherDNID)
+        WallDuration, CpuDuration, NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, NumberOfVMs,  PublisherDNID)
       VALUES (
         SiteLookup(site), CloudComputeServiceLookup(cloudComputeService), month, year, DNLookup(globalUserName), VOLookup(vo),
         VOGroupLookup(voGroup), VORoleLookup(voRole), status, cloudType, imageId, earliestStartTime, latestStartTime, 
-        wallDuration, cpuDuration, networkInbound, networkOutbound, memory,
+        wallDuration, cpuDuration, networkInbound, networkOutbound, publicIPCount, memory,
         disk, numberOfVMs, DNLookup(publisherDN)
         );
 END //
@@ -153,7 +155,7 @@ CREATE PROCEDURE SummariseVMs()
 BEGIN
     REPLACE INTO CloudSummaries(SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID,
         VOGroupID, VORoleID, Status, CloudType, ImageId, EarliestStartTime, LatestStartTime, WallDuration, CpuDuration, NetworkInbound,
-        NetworkOutbound, Memory, Disk, NumberOfVMs, PublisherDNID)
+        NetworkOutbound, PublicIPCount, Memory, Disk, NumberOfVMs, PublisherDNID)
     SELECT SiteID,
     CloudComputeServiceID,
     MONTH(StartTime) AS Month, YEAR(StartTime) AS Year,
@@ -164,6 +166,7 @@ BEGIN
     SUM(CpuDuration),
     SUM(NetworkInbound),
     SUM(NetworkOutbound),
+    SUM(PublicIPCount),
     SUM(Memory),
     SUM(Disk),
     COUNT(*),
@@ -354,7 +357,7 @@ CREATE VIEW VCloudRecords AS
            vogroup.name VOGroup, vorole.name VORole,
            Status, StartTime, EndTime,
            SuspendDuration, WallDuration, CpuDuration, CpuCount, NetworkType,
-           NetworkInbound, NetworkOutbound, Memory, Disk, StorageRecordId, ImageId, CloudType
+           NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, StorageRecordId, ImageId, CloudType
     FROM CloudRecords, Sites site, CloudComputeServices cloudComputeService, DNs userdn, VOs vo, VOGroups vogroup, VORoles vorole WHERE
         SiteID = site.id
         AND CloudComputeServiceID = cloudComputeService.id
@@ -369,7 +372,7 @@ CREATE VIEW VAnonCloudRecords AS
     SELECT UpdateTime, VMUUID, site.name SiteName, cloudComputeService.name CloudComputeService, MachineName,
            LocalUserId, LocalGroupId, GlobalUserNameID, FQAN, vo.name VO,  Status, StartTime, EndTime,
            SuspendDuration, WallDuration, CpuDuration, CpuCount, NetworkType,
-           NetworkInbound, NetworkOutbound, Memory, Disk, StorageRecordId, ImageId, CloudType
+           NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, StorageRecordId, ImageId, CloudType
     FROM CloudRecords, Sites site, CloudComputeServices cloudComputeService, DNs userdn, VOs vo WHERE
         SiteID = site.id
         AND CloudComputeServiceID = cloudComputeService.id
@@ -383,7 +386,7 @@ CREATE VIEW VCloudSummaries AS
            userdn.name GlobalUserName, vo.name VO, 
            vogroup.name VOGroup, vorole.name VORole,
            Status, CloudType, ImageId, EarliestStartTime, LatestStartTime,
-           WallDuration, CpuDuration, NetworkInbound, NetworkOutbound, Memory, Disk, 
+           WallDuration, CpuDuration, NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, 
            NumberOfVMs
     FROM CloudSummaries, Sites site, CloudComputeServices cloudComputeService, DNs userdn, VOs vo, VOGroups vogroup, VORoles vorole WHERE
         SiteID = site.id

--- a/schemas/cloud.sql
+++ b/schemas/cloud.sql
@@ -6,7 +6,7 @@ CREATE TABLE CloudRecords (
 
   VMUUID VARCHAR(255) NOT NULL, 
   SiteID INT NOT NULL,                -- Foreign key
-  CloudComputeServiceID INT,          -- Foreign key
+  CloudComputeServiceID INT NOT NULL, -- Foreign key
 
   MachineName VARCHAR(255), 
 
@@ -96,7 +96,7 @@ CREATE TABLE CloudSummaries (
   UpdateTime TIMESTAMP,
 
   SiteID INT NOT NULL, -- Foreign key
-  CloudComputeServiceID INT, -- Foreign key
+  CloudComputeServiceID INT NOT NULL, -- Foreign key
 
   Month INT NOT NULL,
   Year INT NOT NULL,

--- a/schemas/cloud.sql
+++ b/schemas/cloud.sql
@@ -117,7 +117,7 @@ CREATE TABLE CloudSummaries (
 
   NetworkInbound BIGINT,
   NetworkOutbound BIGINT,
-  PublicIPCount BIGINT,
+  -- PublicIPCount BIGINT,
   Memory BIGINT,
   Disk BIGINT,
  
@@ -140,16 +140,16 @@ CREATE PROCEDURE ReplaceCloudSummaryRecord(
   cloudType VARCHAR(255), imageId VARCHAR(255), 
   earliestStartTime DATETIME, latestStartTime DATETIME, 
   wallDuration BIGINT, cpuDuration BIGINT, 
-  networkInbound BIGINT, networkOutbound BIGINT, publicIPCount BIGINT, memory BIGINT, 
+  networkInbound BIGINT, networkOutbound BIGINT, memory BIGINT,
   disk BIGINT, benchmarkType VARCHAR(50), benchmark DECIMAL(10,3), numberOfVMs BIGINT,
   publisherDN VARCHAR(255))
 BEGIN
     REPLACE INTO CloudSummaries(SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId, EarliestStartTime, LatestStartTime, 
-        WallDuration, CpuDuration, NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, BenchmarkType, Benchmark, NumberOfVMs,  PublisherDNID)
+        WallDuration, CpuDuration, NetworkInbound, NetworkOutbound, Memory, Disk, BenchmarkType, Benchmark, NumberOfVMs,  PublisherDNID)
       VALUES (
         SiteLookup(site), CloudComputeServiceLookup(cloudComputeService), month, year, DNLookup(globalUserName), VOLookup(vo),
         VOGroupLookup(voGroup), VORoleLookup(voRole), status, cloudType, imageId, earliestStartTime, latestStartTime, 
-        wallDuration, cpuDuration, networkInbound, networkOutbound, publicIPCount, memory,
+        wallDuration, cpuDuration, networkInbound, networkOutbound, memory,
         disk, benchmarkType, benchmark, numberOfVMs, DNLookup(publisherDN)
         );
 END //
@@ -162,7 +162,7 @@ CREATE PROCEDURE SummariseVMs()
 BEGIN
     REPLACE INTO CloudSummaries(SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID,
         VOGroupID, VORoleID, Status, CloudType, ImageId, EarliestStartTime, LatestStartTime, WallDuration, CpuDuration, NetworkInbound,
-        NetworkOutbound, PublicIPCount, Memory, Disk, BenchmarkType, Benchmark, NumberOfVMs, PublisherDNID)
+        NetworkOutbound, Memory, Disk, BenchmarkType, Benchmark, NumberOfVMs, PublisherDNID)
     SELECT SiteID,
     CloudComputeServiceID,
     MONTH(StartTime) AS Month, YEAR(StartTime) AS Year,
@@ -173,7 +173,6 @@ BEGIN
     SUM(CpuDuration),
     SUM(NetworkInbound),
     SUM(NetworkOutbound),
-    SUM(PublicIPCount),
     SUM(Memory),
     SUM(Disk),
     BenchmarkType,
@@ -395,7 +394,7 @@ CREATE VIEW VCloudSummaries AS
            userdn.name GlobalUserName, vo.name VO, 
            vogroup.name VOGroup, vorole.name VORole,
            Status, CloudType, ImageId, EarliestStartTime, LatestStartTime,
-           WallDuration, CpuDuration, NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, BenchmarkType, Benchmark,  
+           WallDuration, CpuDuration, NetworkInbound, NetworkOutbound, Memory, Disk, BenchmarkType, Benchmark,  
            NumberOfVMs
     FROM CloudSummaries, Sites site, CloudComputeServices cloudComputeService, DNs userdn, VOs vo, VOGroups vogroup, VORoles vorole WHERE
         SiteID = site.id

--- a/schemas/cloud.sql
+++ b/schemas/cloud.sql
@@ -36,6 +36,9 @@ CREATE TABLE CloudRecords (
   Memory INT, 
   Disk INT, 
 
+  BenchmarkType VARCHAR(50) NOT NULL,
+  Benchmark DECIMAL(10,3) NOT NULL,
+
   StorageRecordId VARCHAR(255),
   ImageId VARCHAR(255),
   CloudType VARCHAR(255),
@@ -66,19 +69,20 @@ CREATE PROCEDURE ReplaceCloudRecord(
   wallDuration INT, cpuDuration INT, 
   cpuCount INT, networkType VARCHAR(255),  networkInbound INT, 
   networkOutbound INT, publicIPCount INT, memory INT, 
-  disk INT, storageRecordId VARCHAR(255),
+  disk INT, benchmarkType VARCHAR(50), benchmark DECIMAL(10,3), storageRecordId VARCHAR(255),
   imageId VARCHAR(255), cloudType VARCHAR(255),
   publisherDN VARCHAR(255))
 BEGIN
     REPLACE INTO CloudRecords(VMUUID, SiteID, CloudComputeServiceID, MachineName, LocalUserId, LocalGroupId,
         GlobalUserNameID, FQAN, VOID, VOGroupID, VORoleID, Status, StartTime, EndTime, SuspendDuration,
-        WallDuration, CpuDuration, CpuCount, NetworkType, NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, StorageRecordId, ImageId, CloudType, PublisherDNID)
+        WallDuration, CpuDuration, CpuCount, NetworkType, NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, BenchmarkType, Benchmark, 
+        StorageRecordId, ImageId, CloudType, PublisherDNID)
       VALUES (
         VMUUID, SiteLookup(site), CloudComputeServiceLookup(cloudComputeService), machineName, localUserId, localGroupId, DNLookup(globalUserName), 
         fqan, VOLookup(vo),
         VOGroupLookup(voGroup), VORoleLookup(voRole), status, startTime, endTime, suspendDuration, 
         wallDuration, cpuDuration, cpuCount, networkType, networkInbound, networkOutbound, publicIPCount, memory,
-        disk, storageRecordId, imageId, cloudType, DNLookup(publisherDN)
+        disk, benchmarkType, benchmark, storageRecordId, imageId, cloudType, DNLookup(publisherDN)
         );
 END //
 DELIMITER ;
@@ -117,6 +121,9 @@ CREATE TABLE CloudSummaries (
   Memory BIGINT,
   Disk BIGINT,
  
+  BenchmarkType VARCHAR(50) NOT NULL,
+  Benchmark DECIMAL(10,3) NOT NULL,
+
   NumberOfVMs INT,
   
   PublisherDNID VARCHAR(255),
@@ -134,16 +141,16 @@ CREATE PROCEDURE ReplaceCloudSummaryRecord(
   earliestStartTime DATETIME, latestStartTime DATETIME, 
   wallDuration BIGINT, cpuDuration BIGINT, 
   networkInbound BIGINT, networkOutbound BIGINT, publicIPCount BIGINT, memory BIGINT, 
-  disk BIGINT, numberOfVMs BIGINT,
+  disk BIGINT, benchmarkType VARCHAR(50), benchmark DECIMAL(10,3), numberOfVMs BIGINT,
   publisherDN VARCHAR(255))
 BEGIN
     REPLACE INTO CloudSummaries(SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId, EarliestStartTime, LatestStartTime, 
-        WallDuration, CpuDuration, NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, NumberOfVMs,  PublisherDNID)
+        WallDuration, CpuDuration, NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, BenchmarkType, Benchmark, NumberOfVMs,  PublisherDNID)
       VALUES (
         SiteLookup(site), CloudComputeServiceLookup(cloudComputeService), month, year, DNLookup(globalUserName), VOLookup(vo),
         VOGroupLookup(voGroup), VORoleLookup(voRole), status, cloudType, imageId, earliestStartTime, latestStartTime, 
         wallDuration, cpuDuration, networkInbound, networkOutbound, publicIPCount, memory,
-        disk, numberOfVMs, DNLookup(publisherDN)
+        disk, benchmarkType, benchmark, numberOfVMs, DNLookup(publisherDN)
         );
 END //
 DELIMITER ;
@@ -155,7 +162,7 @@ CREATE PROCEDURE SummariseVMs()
 BEGIN
     REPLACE INTO CloudSummaries(SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID,
         VOGroupID, VORoleID, Status, CloudType, ImageId, EarliestStartTime, LatestStartTime, WallDuration, CpuDuration, NetworkInbound,
-        NetworkOutbound, PublicIPCount, Memory, Disk, NumberOfVMs, PublisherDNID)
+        NetworkOutbound, PublicIPCount, Memory, Disk, BenchmarkType, Benchmark, NumberOfVMs, PublisherDNID)
     SELECT SiteID,
     CloudComputeServiceID,
     MONTH(StartTime) AS Month, YEAR(StartTime) AS Year,
@@ -169,10 +176,12 @@ BEGIN
     SUM(PublicIPCount),
     SUM(Memory),
     SUM(Disk),
+    BenchmarkType,
+    Benchmark,
     COUNT(*),
     'summariser'
     FROM CloudRecords
-    GROUP BY SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId
+    GROUP BY SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId, BenchmarkType, Benchmark
     ORDER BY NULL;
 END //
 DELIMITER ;
@@ -357,7 +366,7 @@ CREATE VIEW VCloudRecords AS
            vogroup.name VOGroup, vorole.name VORole,
            Status, StartTime, EndTime,
            SuspendDuration, WallDuration, CpuDuration, CpuCount, NetworkType,
-           NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, StorageRecordId, ImageId, CloudType
+           NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, BenchmarkType, Benchmark, StorageRecordId, ImageId, CloudType
     FROM CloudRecords, Sites site, CloudComputeServices cloudComputeService, DNs userdn, VOs vo, VOGroups vogroup, VORoles vorole WHERE
         SiteID = site.id
         AND CloudComputeServiceID = cloudComputeService.id
@@ -372,7 +381,7 @@ CREATE VIEW VAnonCloudRecords AS
     SELECT UpdateTime, VMUUID, site.name SiteName, cloudComputeService.name CloudComputeService, MachineName,
            LocalUserId, LocalGroupId, GlobalUserNameID, FQAN, vo.name VO,  Status, StartTime, EndTime,
            SuspendDuration, WallDuration, CpuDuration, CpuCount, NetworkType,
-           NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, StorageRecordId, ImageId, CloudType
+           NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, BenchmarkType, Benchmark, StorageRecordId, ImageId, CloudType
     FROM CloudRecords, Sites site, CloudComputeServices cloudComputeService, DNs userdn, VOs vo WHERE
         SiteID = site.id
         AND CloudComputeServiceID = cloudComputeService.id
@@ -386,7 +395,7 @@ CREATE VIEW VCloudSummaries AS
            userdn.name GlobalUserName, vo.name VO, 
            vogroup.name VOGroup, vorole.name VORole,
            Status, CloudType, ImageId, EarliestStartTime, LatestStartTime,
-           WallDuration, CpuDuration, NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, 
+           WallDuration, CpuDuration, NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, BenchmarkType, Benchmark,  
            NumberOfVMs
     FROM CloudSummaries, Sites site, CloudComputeServices cloudComputeService, DNs userdn, VOs vo, VOGroups vogroup, VORoles vorole WHERE
         SiteID = site.id

--- a/scripts/update_schema.sql
+++ b/scripts/update_schema.sql
@@ -1,0 +1,179 @@
+-- Create / Update Tables
+-- Add CloudComputeServiceID, old rows get a NULL CloudComputeServiceID
+ALTER TABLE CloudRecords ADD CloudComputeServiceID INT;
+ALTER TABLE CloudSummaries ADD CloudComputeServiceID INT;
+
+-- Add PublicIPCount, old rows get a NULL PublicIPCount
+ALTER TABLE CloudRecords ADD PublicIPCount INT;
+ALTER TABLE CloudSummaries ADD PublicIPCount BIGINT;
+
+-- Add BenchmarkType, old rows get an empty VARCHAR
+ALTER TABLE CloudRecords ADD BenchmarkType VARCHAR(50) NOT NULL;
+ALTER TABLE CloudSummaries ADD BenchmarkType VARCHAR(50) NOT NULL;
+
+-- Add Benchmark, old rows get 0.00
+ALTER TABLE CloudRecords ADD Benchmark DECIMAL(10,3) NOT NULL;
+ALTER TABLE CloudSummaries ADD Benchmark DECIMAL(10,3) NOT NULL;
+
+-- Create CloudComputeService
+CREATE TABLE CloudComputeServices (
+    id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    INDEX(name)
+);
+
+-- Create Views
+-- View on CloudRecords
+DROP VIEW IF EXISTS VCloudRecords;
+CREATE VIEW VCloudRecords AS
+    SELECT UpdateTime, VMUUID, site.name SiteName, cloudComputeService.name CloudComputeService, MachineName, 
+           LocalUserId, LocalGroupId, userdn.name GlobalUserName, FQAN, vo.name VO, 
+           vogroup.name VOGroup, vorole.name VORole,
+           Status, StartTime, EndTime,
+           SuspendDuration, WallDuration, CpuDuration, CpuCount, NetworkType,
+           NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, BenchmarkType, Benchmark, StorageRecordId, ImageId, CloudType
+    FROM CloudRecords, Sites site, CloudComputeServices cloudComputeService, DNs userdn, VOs vo, VOGroups vogroup, VORoles vorole WHERE
+        SiteID = site.id
+        AND CloudComputeServiceID = cloudComputeService.id
+        AND GlobalUserNameID = userdn.id
+        AND VOID = vo.id
+        AND VOGroupID = vogroup.id
+        AND VORoleID = vorole.id;
+
+-- View on CloudRecords
+DROP VIEW IF EXISTS VAnonCloudRecords;
+CREATE VIEW VAnonCloudRecords AS
+    SELECT UpdateTime, VMUUID, site.name SiteName, cloudComputeService.name CloudComputeService
+	       MachineName, LocalUserId, LocalGroupId, GlobalUserNameID, FQAN, vo.name VO,  Status, 
+		   StartTime, EndTime, SuspendDuration, WallDuration, CpuDuration, CpuCount, NetworkType,
+           NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, BenchmarkType, Benchmark,
+           StorageRecordId, ImageId, CloudType
+    FROM CloudRecords, Sites site, CloudComputeServices cloudComputeService, DNs userdn, VOs vo WHERE
+        SiteID = site.id
+        AND CloudComputeServiceID = cloudComputeService.id
+        AND GlobalUserNameID = userdn.id
+        AND VOID = vo.id;
+
+-- View on CloudSummaries
+DROP VIEW IF EXISTS VCloudSummaries;
+CREATE VIEW VCloudSummaries AS
+    SELECT UpdateTime, site.name SiteName, cloudComputeService.name CloudComputeService, Month, Year,
+           userdn.name GlobalUserName, vo.name VO, vogroup.name VOGroup, vorole.name VORole, Status,
+		   CloudType, ImageId, EarliestStartTime, LatestStartTime, WallDuration, CpuDuration,
+           NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, BenchmarkType, Benchmark,  
+           NumberOfVMs
+    FROM CloudSummaries, Sites site, CloudComputeServices cloudComputeService, DNs userdn, VOs vo, VOGroups vogroup, VORoles vorole WHERE
+        SiteID = site.id
+        AND CloudComputeServiceID = cloudComputeService.id
+        AND GlobalUserNameID = userdn.id
+        AND VOID = vo.id
+        AND VOGroupID = vogroup.id
+        AND VORoleID = vorole.id;
+
+
+-- Create / Replace Functions / Procedures
+-- Create CloudComputeServiceLookup
+DROP FUNCTION IF EXISTS CloudComputeServiceLookup;
+DELIMITER //
+CREATE FUNCTION CloudComputeServiceLookup(lookup VARCHAR(255)) RETURNS INTEGER DETERMINISTIC
+BEGIN
+    DECLARE result INTEGER;
+    SELECT id FROM CloudComputeServices WHERE name=lookup INTO result;
+    IF result IS NULL THEN
+        INSERT INTO CloudComputeServices(name) VALUES (lookup);
+        SET result=LAST_INSERT_ID();
+    END IF;
+RETURN result;
+END //
+DELIMITER ;
+
+-- Replace ReplaceCloudRecords
+DROP PROCEDURE IF EXISTS ReplaceCloudRecord;
+DELIMITER //
+CREATE PROCEDURE ReplaceCloudRecord(
+  VMUUID VARCHAR(255), site VARCHAR(255), cloudComputeService VARCHAR(255),
+  machineName VARCHAR(255), 
+  localUserId VARCHAR(255),
+  localGroupId VARCHAR(255), globalUserName VARCHAR(255), 
+  fqan VARCHAR(255), vo VARCHAR(255), 
+  voGroup VARCHAR(255), voRole VARCHAR(255), status VARCHAR(255),
+  startTime DATETIME, endTime DATETIME, 
+  suspendDuration INT,
+  wallDuration INT, cpuDuration INT, 
+  cpuCount INT, networkType VARCHAR(255),  networkInbound INT, 
+  networkOutbound INT, publicIPCount INT, memory INT, 
+  disk INT, benchmarkType VARCHAR(50), benchmark DECIMAL(10,3), storageRecordId VARCHAR(255),
+  imageId VARCHAR(255), cloudType VARCHAR(255),
+  publisherDN VARCHAR(255))
+BEGIN
+    REPLACE INTO CloudRecords(VMUUID, SiteID, CloudComputeServiceID, MachineName, LocalUserId, LocalGroupId,
+        GlobalUserNameID, FQAN, VOID, VOGroupID, VORoleID, Status, StartTime, EndTime, SuspendDuration,
+        WallDuration, CpuDuration, CpuCount, NetworkType, NetworkInbound, NetworkOutbound, PublicIPCount,
+        Memory, Disk, BenchmarkType, Benchmark, StorageRecordId, ImageId, CloudType, PublisherDNID)
+      VALUES (
+        VMUUID, SiteLookup(site), CloudComputeServiceLookup(cloudComputeService), machineName, localUserId,
+        localGroupId, DNLookup(globalUserName), fqan, VOLookup(vo), VOGroupLookup(voGroup), VORoleLookup(voRole),
+        status, startTime, endTime, suspendDuration, 
+        wallDuration, 
+        cpuDuration, cpuCount, networkType, networkInbound, networkOutbound, publicIPCount, memory,
+        disk, benchmarkType, benchmark, storageRecordId, imageId, cloudType, DNLookup(publisherDN)
+        );
+END //
+DELIMITER ;
+
+-- Replace ReplaceCloudSummaryRecords
+DROP PROCEDURE IF EXISTS ReplaceCloudSummaryRecord;
+DELIMITER //
+CREATE PROCEDURE ReplaceCloudSummaryRecord(
+  site VARCHAR(255), cloudComputeService VARCHAR(255), month INT, year INT, globalUserName VARCHAR(255), 
+  vo VARCHAR(255), voGroup VARCHAR(255), voRole VARCHAR(255), status VARCHAR(255),
+  cloudType VARCHAR(255), imageId VARCHAR(255), 
+  earliestStartTime DATETIME, latestStartTime DATETIME, 
+  wallDuration BIGINT, cpuDuration BIGINT, 
+  networkInbound BIGINT, networkOutbound BIGINT, publicIPCount BIGINT, memory BIGINT, 
+  disk BIGINT, benchmarkType VARCHAR(50), benchmark DECIMAL(10,3), numberOfVMs BIGINT,
+  publisherDN VARCHAR(255))
+BEGIN
+    REPLACE INTO CloudSummaries(SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID,
+        VOGroupID, VORoleID, Status, CloudType, ImageId, EarliestStartTime, LatestStartTime, 
+        WallDuration, CpuDuration, NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk,
+        BenchmarkType, Benchmark, NumberOfVMs,  PublisherDNID)
+      VALUES (
+        SiteLookup(site), CloudComputeServiceLookup(cloudComputeService), month, year, DNLookup(globalUserName),
+        VOLookup(vo), VOGroupLookup(voGroup), VORoleLookup(voRole), status, cloudType, imageId,
+        earliestStartTime, latestStartTime, wallDuration, cpuDuration, networkInbound, networkOutbound,
+        publicIPCount, memory, disk, benchmarkType, benchmark, numberOfVMs, DNLookup(publisherDN)
+        );
+END //
+DELIMITER ;
+
+-- Replace SummariesVMs
+DROP PROCEDURE IF EXISTS SummariseVMs;
+DELIMITER //
+CREATE PROCEDURE SummariseVMs()
+BEGIN
+    REPLACE INTO CloudSummaries(SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID,
+        VOGroupID, VORoleID, Status, CloudType, ImageId, EarliestStartTime, LatestStartTime, WallDuration, CpuDuration, NetworkInbound,
+        NetworkOutbound, PublicIPCount, Memory, Disk, BenchmarkType, Benchmark, NumberOfVMs, PublisherDNID)
+    SELECT SiteID,
+    CloudComputeServiceID,
+    MONTH(StartTime) AS Month, YEAR(StartTime) AS Year,
+    GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId,
+    MIN(StartTime),
+    MAX(StartTime),
+    SUM(WallDuration),
+    SUM(CpuDuration),
+    SUM(NetworkInbound),
+    SUM(NetworkOutbound),
+    SUM(PublicIPCount),
+    SUM(Memory),
+    SUM(Disk),
+    BenchmarkType,
+    Benchmark,
+    COUNT(*),
+    'summariser'
+    FROM CloudRecords
+    GROUP BY SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId, BenchmarkType, Benchmark
+    ORDER BY NULL;
+END //
+DELIMITER ;

--- a/scripts/update_schema.sql
+++ b/scripts/update_schema.sql
@@ -111,9 +111,9 @@ BEGIN
         WallDuration, CpuDuration, CpuCount, NetworkType, NetworkInbound, NetworkOutbound, PublicIPCount,
         Memory, Disk, BenchmarkType, Benchmark, StorageRecordId, ImageId, CloudType, PublisherDNID)
       VALUES (
-        VMUUID, SiteLookup(site), CloudComputeServiceLookup(cloudComputeService), machineName, localUserId,
-        localGroupId, DNLookup(globalUserName), fqan, VOLookup(vo), VOGroupLookup(voGroup), VORoleLookup(voRole),
-        status, startTime, endTime, suspendDuration, 
+        VMUUID, SiteLookup(site), CloudComputeServiceLookup(cloudComputeService), machineName,
+        localUserId, localGroupId, DNLookup(globalUserName), fqan, VOLookup(vo), VOGroupLookup(voGroup),
+        VORoleLookup(voRole), status, startTime, endTime, suspendDuration, 
         wallDuration, 
         cpuDuration, cpuCount, networkType, networkInbound, networkOutbound, publicIPCount, memory,
         disk, benchmarkType, benchmark, storageRecordId, imageId, cloudType, DNLookup(publisherDN)
@@ -139,10 +139,11 @@ BEGIN
         WallDuration, CpuDuration, NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk,
         BenchmarkType, Benchmark, NumberOfVMs,  PublisherDNID)
       VALUES (
-        SiteLookup(site), CloudComputeServiceLookup(cloudComputeService), month, year, DNLookup(globalUserName),
-        VOLookup(vo), VOGroupLookup(voGroup), VORoleLookup(voRole), status, cloudType, imageId,
-        earliestStartTime, latestStartTime, wallDuration, cpuDuration, networkInbound, networkOutbound,
-        publicIPCount, memory, disk, benchmarkType, benchmark, numberOfVMs, DNLookup(publisherDN)
+        SiteLookup(site), CloudComputeServiceLookup(cloudComputeService), month, year,
+        DNLookup(globalUserName), VOLookup(vo), VOGroupLookup(voGroup), VORoleLookup(voRole),
+        status, cloudType, imageId, earliestStartTime, latestStartTime, wallDuration,
+        cpuDuration, networkInbound, networkOutbound, publicIPCount, memory, disk, benchmarkType,
+        benchmark, numberOfVMs, DNLookup(publisherDN)
         );
 END //
 DELIMITER ;
@@ -153,27 +154,29 @@ DELIMITER //
 CREATE PROCEDURE SummariseVMs()
 BEGIN
     REPLACE INTO CloudSummaries(SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID,
-        VOGroupID, VORoleID, Status, CloudType, ImageId, EarliestStartTime, LatestStartTime, WallDuration, CpuDuration, NetworkInbound,
-        NetworkOutbound, PublicIPCount, Memory, Disk, BenchmarkType, Benchmark, NumberOfVMs, PublisherDNID)
+        VOGroupID, VORoleID, Status, CloudType, ImageId, EarliestStartTime, LatestStartTime,
+        WallDuration, CpuDuration, NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk,
+        BenchmarkType, Benchmark, NumberOfVMs, PublisherDNID)
     SELECT SiteID,
-    CloudComputeServiceID,
-    MONTH(StartTime) AS Month, YEAR(StartTime) AS Year,
-    GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId,
-    MIN(StartTime),
-    MAX(StartTime),
-    SUM(WallDuration),
-    SUM(CpuDuration),
-    SUM(NetworkInbound),
-    SUM(NetworkOutbound),
-    SUM(PublicIPCount),
-    SUM(Memory),
-    SUM(Disk),
-    BenchmarkType,
-    Benchmark,
-    COUNT(*),
-    'summariser'
+        CloudComputeServiceID,
+        MONTH(StartTime) AS Month, YEAR(StartTime) AS Year,
+        GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId,
+        MIN(StartTime),
+        MAX(StartTime),
+        SUM(WallDuration),
+        SUM(CpuDuration),
+        SUM(NetworkInbound),
+        SUM(NetworkOutbound),
+        SUM(PublicIPCount),
+        SUM(Memory),
+        SUM(Disk),
+        BenchmarkType,
+        Benchmark,
+        COUNT(*),
+        'summariser'
     FROM CloudRecords
-    GROUP BY SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId, BenchmarkType, Benchmark
+    GROUP BY SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID,
+        Status, CloudType, ImageId, BenchmarkType, Benchmark
     ORDER BY NULL;
 END //
 DELIMITER ;

--- a/scripts/update_schema.sql
+++ b/scripts/update_schema.sql
@@ -92,16 +92,16 @@ DROP PROCEDURE IF EXISTS ReplaceCloudRecord;
 DELIMITER //
 CREATE PROCEDURE ReplaceCloudRecord(
   VMUUID VARCHAR(255), site VARCHAR(255), cloudComputeService VARCHAR(255),
-  machineName VARCHAR(255), 
+  machineName VARCHAR(255),
   localUserId VARCHAR(255),
   localGroupId VARCHAR(255), globalUserName VARCHAR(255), 
-  fqan VARCHAR(255), vo VARCHAR(255), 
+  fqan VARCHAR(255), vo VARCHAR(255),
   voGroup VARCHAR(255), voRole VARCHAR(255), status VARCHAR(255),
-  startTime DATETIME, endTime DATETIME, 
+  startTime DATETIME, endTime DATETIME,
   suspendDuration INT,
-  wallDuration INT, cpuDuration INT, 
-  cpuCount INT, networkType VARCHAR(255),  networkInbound INT, 
-  networkOutbound INT, publicIPCount INT, memory INT, 
+  wallDuration INT, cpuDuration INT,
+  cpuCount INT, networkType VARCHAR(255),  networkInbound INT,
+  networkOutbound INT, publicIPCount INT, memory INT,
   disk INT, benchmarkType VARCHAR(50), benchmark DECIMAL(10,3), storageRecordId VARCHAR(255),
   imageId VARCHAR(255), cloudType VARCHAR(255),
   publisherDN VARCHAR(255))

--- a/scripts/update_schema.sql
+++ b/scripts/update_schema.sql
@@ -1,7 +1,7 @@
 -- Create / Update Tables
--- Add CloudComputeServiceID, old rows get a NULL CloudComputeServiceID
-ALTER TABLE CloudRecords ADD CloudComputeServiceID INT;
-ALTER TABLE CloudSummaries ADD CloudComputeServiceID INT;
+-- Add CloudComputeServiceID, old rows get set to 1
+ALTER TABLE CloudRecords ADD CloudComputeServiceID INT NOT NULL DEFAULT 1;
+ALTER TABLE CloudSummaries ADD CloudComputeServiceID INT NOT NULL DEFAULT 1;
 
 -- Add PublicIPCount, old rows get a NULL PublicIPCount
 ALTER TABLE CloudRecords ADD PublicIPCount INT;
@@ -21,6 +21,8 @@ CREATE TABLE CloudComputeServices (
     name VARCHAR(255) NOT NULL,
     INDEX(name)
 );
+
+INSERT INTO CloudComputeServices (id, name) VALUES(1, "None");
 
 -- Create Views
 -- View on CloudRecords

--- a/scripts/update_schema.sql
+++ b/scripts/update_schema.sql
@@ -1,21 +1,35 @@
 -- Create / Update Tables
--- Add CloudComputeServiceID, old rows get set to 1
-ALTER TABLE CloudRecords ADD CloudComputeServiceID INT NOT NULL DEFAULT 1;
-ALTER TABLE CloudSummaries ADD CloudComputeServiceID INT NOT NULL DEFAULT 1;
 
--- Add PublicIPCount, old rows get a NULL PublicIPCount
-ALTER TABLE CloudRecords ADD PublicIPCount INT;
-ALTER TABLE CloudSummaries ADD PublicIPCount BIGINT;
+/* Update CloudRecords
 
--- Add BenchmarkType, old rows get an empty VARCHAR
-ALTER TABLE CloudRecords ADD BenchmarkType VARCHAR(50) NOT NULL;
-ALTER TABLE CloudSummaries ADD BenchmarkType VARCHAR(50) NOT NULL;
+Existing rows get set to the following:
 
--- Add Benchmark, old rows get 0.00
-ALTER TABLE CloudRecords ADD Benchmark DECIMAL(10,3) NOT NULL;
-ALTER TABLE CloudSummaries ADD Benchmark DECIMAL(10,3) NOT NULL;
+CloudComputeServiceID - set afterwards
+PublicIPCount - null (NULL)
+BenchmarkType - empty VARCHAR ("")
+Benchmark - decimal zero (0.00)
+*/
+ALTER TABLE CloudRecords
+  ADD CloudComputeServiceID INT NOT NULL AFTER SiteID,
+  ADD PublicIPCount INT AFTER NetworkOutbound,
+  ADD BenchmarkType VARCHAR(50) NOT NULL AFTER Disk,
+  ADD Benchmark DECIMAL(10,3) NOT NULL AFTER BenchmarkType;
 
--- Create CloudComputeService
+
+/* Update CloudSummaries
+
+Existing rows get same values as for CloudRecords
+
+PublicIPCount is not currently used in summaries
+*/
+ALTER TABLE CloudSummaries
+  ADD CloudComputeServiceID INT NOT NULL AFTER SiteID,
+  -- ADD PublicIPCount BIGINT AFTER NetworkOutbound,
+  ADD BenchmarkType VARCHAR(50) NOT NULL AFTER Disk,
+  ADD Benchmark DECIMAL(10,3) NOT NULL AFTER BenchmarkType;
+
+
+-- Create CloudComputeServices lookup table
 CREATE TABLE CloudComputeServices (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
@@ -25,8 +39,10 @@ CREATE TABLE CloudComputeServices (
 -- Insert row for "None" which can be used as a default value
 INSERT INTO CloudComputeServices (id, name) VALUES(1, "None");
 
--- Update the existing rows in the CloudRecords table with a default value
+-- Update the existing rows in the Cloud tables with a default value
 UPDATE CloudRecords SET CloudComputeServiceID=1;
+
+UPDATE CloudSummaries SET CloudComputeServiceID=1;
 
 
 -- Create Views

--- a/scripts/update_schema.sql
+++ b/scripts/update_schema.sql
@@ -43,9 +43,9 @@ CREATE VIEW VCloudRecords AS
 -- View on CloudRecords
 DROP VIEW IF EXISTS VAnonCloudRecords;
 CREATE VIEW VAnonCloudRecords AS
-    SELECT UpdateTime, VMUUID, site.name SiteName, cloudComputeService.name CloudComputeService
-	       MachineName, LocalUserId, LocalGroupId, GlobalUserNameID, FQAN, vo.name VO,  Status, 
-		   StartTime, EndTime, SuspendDuration, WallDuration, CpuDuration, CpuCount, NetworkType,
+    SELECT UpdateTime, VMUUID, site.name SiteName, cloudComputeService.name CloudComputeService,
+           MachineName, LocalUserId, LocalGroupId, GlobalUserNameID, FQAN, vo.name VO,  Status, 
+           StartTime, EndTime, SuspendDuration, WallDuration, CpuDuration, CpuCount, NetworkType,
            NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, BenchmarkType, Benchmark,
            StorageRecordId, ImageId, CloudType
     FROM CloudRecords, Sites site, CloudComputeServices cloudComputeService, DNs userdn, VOs vo WHERE

--- a/scripts/update_schema.sql
+++ b/scripts/update_schema.sql
@@ -82,8 +82,8 @@ DROP VIEW IF EXISTS VCloudSummaries;
 CREATE VIEW VCloudSummaries AS
     SELECT UpdateTime, site.name SiteName, cloudComputeService.name CloudComputeService, Month, Year,
            userdn.name GlobalUserName, vo.name VO, vogroup.name VOGroup, vorole.name VORole, Status,
-		   CloudType, ImageId, EarliestStartTime, LatestStartTime, WallDuration, CpuDuration,
-           NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, BenchmarkType, Benchmark,  
+                   CloudType, ImageId, EarliestStartTime, LatestStartTime, WallDuration, CpuDuration,
+           NetworkInbound, NetworkOutbound, Memory, Disk, BenchmarkType, Benchmark,
            NumberOfVMs
     FROM CloudSummaries, Sites site, CloudComputeServices cloudComputeService, DNs userdn, VOs vo, VOGroups vogroup, VORoles vorole WHERE
         SiteID = site.id
@@ -153,19 +153,19 @@ CREATE PROCEDURE ReplaceCloudSummaryRecord(
   cloudType VARCHAR(255), imageId VARCHAR(255), 
   earliestStartTime DATETIME, latestStartTime DATETIME, 
   wallDuration BIGINT, cpuDuration BIGINT, 
-  networkInbound BIGINT, networkOutbound BIGINT, publicIPCount BIGINT, memory BIGINT, 
+  networkInbound BIGINT, networkOutbound BIGINT, memory BIGINT,
   disk BIGINT, benchmarkType VARCHAR(50), benchmark DECIMAL(10,3), numberOfVMs BIGINT,
   publisherDN VARCHAR(255))
 BEGIN
     REPLACE INTO CloudSummaries(SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID,
         VOGroupID, VORoleID, Status, CloudType, ImageId, EarliestStartTime, LatestStartTime, 
-        WallDuration, CpuDuration, NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk,
+        WallDuration, CpuDuration, NetworkInbound, NetworkOutbound, Memory, Disk,
         BenchmarkType, Benchmark, NumberOfVMs,  PublisherDNID)
       VALUES (
         SiteLookup(site), CloudComputeServiceLookup(cloudComputeService), month, year,
         DNLookup(globalUserName), VOLookup(vo), VOGroupLookup(voGroup), VORoleLookup(voRole),
         status, cloudType, imageId, earliestStartTime, latestStartTime, wallDuration,
-        cpuDuration, networkInbound, networkOutbound, publicIPCount, memory, disk, benchmarkType,
+        cpuDuration, networkInbound, networkOutbound, memory, disk, benchmarkType,
         benchmark, numberOfVMs, DNLookup(publisherDN)
         );
 END //
@@ -178,7 +178,7 @@ CREATE PROCEDURE SummariseVMs()
 BEGIN
     REPLACE INTO CloudSummaries(SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID,
         VOGroupID, VORoleID, Status, CloudType, ImageId, EarliestStartTime, LatestStartTime,
-        WallDuration, CpuDuration, NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk,
+        WallDuration, CpuDuration, NetworkInbound, NetworkOutbound, Memory, Disk,
         BenchmarkType, Benchmark, NumberOfVMs, PublisherDNID)
     SELECT SiteID,
         CloudComputeServiceID,
@@ -190,7 +190,6 @@ BEGIN
         SUM(CpuDuration),
         SUM(NetworkInbound),
         SUM(NetworkOutbound),
-        SUM(PublicIPCount),
         SUM(Memory),
         SUM(Disk),
         BenchmarkType,

--- a/scripts/update_schema.sql
+++ b/scripts/update_schema.sql
@@ -22,7 +22,12 @@ CREATE TABLE CloudComputeServices (
     INDEX(name)
 );
 
+-- Insert row for "None" which can be used as a default value
 INSERT INTO CloudComputeServices (id, name) VALUES(1, "None");
+
+-- Update the existing rows in the CloudRecords table with a default value
+UPDATE CloudRecords SET CloudComputeServiceID=1;
+
 
 -- Create Views
 -- View on CloudRecords

--- a/test/test_cloud_record.py
+++ b/test/test_cloud_record.py
@@ -73,7 +73,7 @@ CloudType: OpenNebula
                         'PublicIPCount': 5,
                         'Memory': 512,
                         'BenchmarkType': 'Hepspec',
-                        'Benchmark': '1006.3',
+                        'Benchmark': 1006.3,
                         'ImageId': '\'scilin6\'',
                         'CloudType': 'OpenNebula'
                         }
@@ -121,7 +121,7 @@ CloudType: Openstack
                         'PublicIPCount': 1,
                         'Memory': 512,
                         'BenchmarkType': 'Si2k',
-                        'Benchmark': '200',
+                        'Benchmark': 200,
                         'ImageId': 'Debian Testing (Wheezy)',
                         'CloudType': 'Openstack'                  
                          }

--- a/test/test_cloud_record.py
+++ b/test/test_cloud_record.py
@@ -1,7 +1,9 @@
-from apel.db.records import CloudRecord
-from unittest import TestCase
+import unittest
 
-class CloudRecordTest(TestCase):
+from apel.db.records import CloudRecord
+
+
+class CloudRecordTest(unittest.TestCase):
     '''
     Test case for CloudRecord
     '''
@@ -153,3 +155,6 @@ CloudType: Openstack
             record._check_fields()
         except Exception, e:
             self.fail('_check_fields method failed: %s [%s]' % (str(e), str(type(e))))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_cloud_record.py
+++ b/test/test_cloud_record.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 class CloudRecordTest(TestCase):
     '''
-    Test case for StorageRecord
+    Test case for CloudRecord
     '''
     
 #    def test_load_from_tuple(self):
@@ -39,6 +39,7 @@ class CloudRecordTest(TestCase):
         self._msg1 = '''
 VMUUID: 2012-12-04 09:15:01+00:00 CESNET vm-0
 SiteName: CESNET
+CloudComputeService: OpenNebula Service A
 MachineName: 'one-0'
 LocalUserId: 5
 LocalGroupId: 1
@@ -54,18 +55,25 @@ CpuCount: 1
 NetworkType: NULL
 NetworkInbound: 0
 NetworkOutbound: 0
+PublicIPCount: 5
 Memory: 512
 Disk: NULL
+BenchmarkType: Hepspec
+Benchmark: 1006.3
 StorageRecordId: NULL
 ImageId: 'scilin6'
 CloudType: OpenNebula
 '''
         self._values1 = {'SiteName': 'CESNET',
+                        'CloudComputeService': 'OpenNebula Service A', 
                         'MachineName': '\'one-0\'',
                         'LocalUserId': '5',
                         'Status': 'completed',
                         'CpuCount': 1,
+                        'PublicIPCount': 5,
                         'Memory': 512,
+                        'BenchmarkType': 'Hepspec',
+                        'Benchmark': 1006.3,
                         'ImageId': '\'scilin6\'',
                         'CloudType': 'OpenNebula'
                         }
@@ -73,6 +81,7 @@ CloudType: OpenNebula
         self._msg2 = '''
 VMUUID: 2012-08-14 14:00:01+0200 FZJ Accounting Test
 SiteName: FZJ
+CloudComputeService: OpenStack Service A
 MachineName: Accounting Test
 LocalUserId: 1189105086dc4959bc9889383afc43b5
 LocalGroupId: EGI FCTF
@@ -88,14 +97,18 @@ CpuCount: 1
 NetworkType: NULL
 NetworkInbound: NULL
 NetworkOutbound: NULL
+PublicIPCount: 1
 Memory: 512
 Disk: 0
+BenchmarkType: Si2k
+Benchmark: 200
 StorageRecordId: NULL
 ImageId: Debian Testing (Wheezy)
 CloudType: Openstack
 '''
 
         self._values2 = {'SiteName': 'FZJ',
+                        'CloudComputeService': 'OpenStack Service A', 
                         'MachineName': 'Accounting Test',
                         'LocalUserId': '1189105086dc4959bc9889383afc43b5',
                         'GlobalUserName': '/DC=es/DC=irisgrid/O=cesga/CN=javier-lopez',
@@ -105,7 +118,10 @@ CloudType: Openstack
                         'VORole': 'Role=NULL',
                         'Status': 'started',
                         'CpuCount': 1,
+                        'PublicIPCount': 1,
                         'Memory': 512,
+                        'BenchmarkType': 'Si2k',
+                        'Benchmark': 200,
                         'ImageId': 'Debian Testing (Wheezy)',
                         'CloudType': 'Openstack'                  
                          }

--- a/test/test_cloud_record.py
+++ b/test/test_cloud_record.py
@@ -73,7 +73,7 @@ CloudType: OpenNebula
                         'PublicIPCount': 5,
                         'Memory': 512,
                         'BenchmarkType': 'Hepspec',
-                        'Benchmark': 1006.3,
+                        'Benchmark': '1006.3',
                         'ImageId': '\'scilin6\'',
                         'CloudType': 'OpenNebula'
                         }
@@ -121,7 +121,7 @@ CloudType: Openstack
                         'PublicIPCount': 1,
                         'Memory': 512,
                         'BenchmarkType': 'Si2k',
-                        'Benchmark': 200,
+                        'Benchmark': '200',
                         'ImageId': 'Debian Testing (Wheezy)',
                         'CloudType': 'Openstack'                  
                          }

--- a/test/test_cloud_record.py
+++ b/test/test_cloud_record.py
@@ -127,10 +127,50 @@ CloudType: Openstack
                         'ImageId': 'Debian Testing (Wheezy)',
                         'CloudType': 'Openstack'                  
                          }
-        
+
+        # A v0.2 style message, used to check we can still
+        # support a v0.2 cloud message
+        self._msg3 = '''
+VMUUID: 2013-11-14 19:15:21+00:00 CESNET vm-1
+SiteName: CESNET
+MachineName: 'one-1'
+LocalUserId: 5
+LocalGroupId: 1
+GlobalUserName: NULL
+FQAN: NULL
+Status: completed
+StartTime: 1318842264
+EndTime: 1318849976
+SuspendDuration: NULL
+WallDuration: NULL
+CpuDuration: NULL
+CpuCount: 1
+NetworkType: NULL
+NetworkInbound: 0
+NetworkOutbound: 0
+Memory: 512
+Disk: NULL
+StorageRecordId: NULL
+ImageId: 'scilin6'
+CloudType: OpenNebula
+'''
+
+        self._values3 = {'SiteName': 'CESNET',
+                         'CloudComputeService': 'None',
+                         'MachineName': '\'one-1\'',
+                         'LocalUserId': '5',
+                         'Status': 'completed',
+                         'CpuCount': 1,
+                         'PublicIPCount': None,
+                         'Memory': 512,
+                         'BenchmarkType': 'None',
+                         'Benchmark': 'None',
+                         'ImageId': '\'scilin6\'',
+                         'CloudType': 'OpenNebula'}
         self.cases = {}
         self.cases[self._msg1] = self._values1
         self.cases[self._msg2] = self._values2
+        self.cases[self._msg3] = self._values3
 
     def test_load_from_msg(self):
         

--- a/test/test_cloud_summary.py
+++ b/test/test_cloud_summary.py
@@ -9,6 +9,7 @@ class CloudRecordTest(TestCase):
     def setUp(self):
         self._msg1 = '''
 SiteName: CESNET
+CloudComputeService: OpenNebula Service A
 Month: 10
 Year: 2011
 GlobalUserName: /DC=es/DC=irisgrid/O=cesga/CN=javier-lopez
@@ -24,18 +25,25 @@ WallDuration: None
 CpuDuration: None
 NetworkInbound: 0
 NetworkOutbound: 0
+PublicIPCount: 5
 Memory: 512
 Disk: None
+BenchmarkType: Si2k
+Benchmark: 1006.3
 NumberOfVMs: 1
 '''
         
         self._values1 = {'SiteName': 'CESNET',
+                        'CloudComputeService': 'OpenNebula Service A', 
                         'Status': 'completed',
                         'CloudType': 'OpenNebula',
                         'NetworkInbound': 0,
                         'NetworkOutbound': 0,
+                        'PublicIPCount': 5,
                         'Memory': 512,
                         'ImageId': '\'scilin6\'',
+                        'BenchmarkType': 'Si2k',
+                        'Benchmark': 1006.3,
                         'NumberOfVMs': 1
                         }
         

--- a/test/test_cloud_summary.py
+++ b/test/test_cloud_summary.py
@@ -1,7 +1,9 @@
-from apel.db.records import CloudSummaryRecord
-from unittest import TestCase
+import unittest
 
-class CloudRecordTest(TestCase):
+from apel.db.records import CloudSummaryRecord
+
+
+class CloudRecordTest(unittest.TestCase):
     '''
     Test case for CloudSummaryRecord
     '''
@@ -25,7 +27,6 @@ WallDuration: None
 CpuDuration: None
 NetworkInbound: 0
 NetworkOutbound: 0
-PublicIPCount: 5
 Memory: 512
 Disk: None
 BenchmarkType: Si2k
@@ -39,7 +40,6 @@ NumberOfVMs: 1
                         'CloudType': 'OpenNebula',
                         'NetworkInbound': 0,
                         'NetworkOutbound': 0,
-                        'PublicIPCount': 5,
                         'Memory': 512,
                         'ImageId': '\'scilin6\'',
                         'BenchmarkType': 'Si2k',
@@ -82,3 +82,6 @@ NumberOfVMs: 1
             record._check_fields()
         except Exception, e:
             self.fail('_check_fields method failed: %s [%s]' % (str(e), str(type(e))))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Finally resolves #71.
Also resolves #112.

Right, here it is at last! 🤞 

- This PR updates the cloud accounting to support the new schema v0.4 in terms of accepting that format of record and producing summaries from it. Also provided is an update schema for updating from a previous version of the schema.
- PublicIPCount is being excluded from the summaries as there is no agreement on how exactly this should be accounted for, whether as part of the VM record or as a separate resource.
- Currently missing is the inclusion of CPU counts in the cloud summaries - this will be added in a separate PR.

**N.B.** Double check that PublicIPCount only appears in cloud _records_, so that we can accept the record, but not _summaries_ (there a couple of commented out lines though).

(Note to self for future updates involving large changes in schema - keep whitespace changes to a minimum and tidy those up later as it makes the important changes more obvious! :grimacing: )