### PR TITLE
Cloud summary CPU count

### DIFF
--- a/apel/db/backends/mysql.py
+++ b/apel/db/backends/mysql.py
@@ -69,7 +69,7 @@ class ApelMysqlDb(object):
               SyncRecord  : "CALL ReplaceSyncRecord(%s, %s, %s, %s, %s, %s)",
               ProcessedRecord : "CALL ReplaceProcessedFile(%s, %s, %s, %s, %s)",
               CloudRecord : "CALL ReplaceCloudRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
-              CloudSummaryRecord : "CALL ReplaceCloudSummaryRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+              CloudSummaryRecord : "CALL ReplaceCloudSummaryRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
               StorageRecord: "CALL ReplaceStarRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
               GroupAttributeRecord: "CALL ReplaceGroupAttribute(%s, %s, %s)"
               }

--- a/apel/db/records/cloud_summary.py
+++ b/apel/db/records/cloud_summary.py
@@ -38,8 +38,8 @@ class CloudSummaryRecord(Record):
         self._msg_fields  = ['SiteName', 'CloudComputeService', 'Month', 'Year', 
                              'GlobalUserName', 'VO', 'VOGroup', 'VORole',
                              'Status', 'CloudType', 'ImageId', 'EarliestStartTime', 
-                             'LatestStartTime', 'WallDuration', 'CpuDuration', 'NetworkInbound', 
-                             'NetworkOutbound', 'Memory', 'Disk', 
+                             'LatestStartTime', 'WallDuration', 'CpuDuration', 'CpuCount',
+                             'NetworkInbound', 'NetworkOutbound', 'Memory', 'Disk', 
                              'BenchmarkType', 'Benchmark', 'NumberOfVMs']
         
         # This list specifies the information that goes in the database.

--- a/apel/db/records/cloud_summary.py
+++ b/apel/db/records/cloud_summary.py
@@ -12,42 +12,45 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
 @author Will Rogers
 '''
 
 from apel.db.records import Record
 
+
 class CloudSummaryRecord(Record):
     '''
-    Class to represent one cloud summary record. 
-    
+    Class to represent one cloud summary record.
+
     It knows about the structure of the MySQL table and the message format.
-    It stores its information in a dictionary self._record_content.  The keys 
+    It stores its information in a dictionary self._record_content.  The keys
     are in the same format as in the messages, and are case-sensitive.
     '''
     def __init__(self):
         '''Provide the necessary lists containing message information.'''
-        
+
         Record.__init__(self)
-        
+
         # Fields which are required by the message format.
         self._mandatory_fields = ['SiteName', 'Month', 'Year', 'NumberOfVMs']
-            
+
         # This list allows us to specify the order of lines when we construct records.
-        self._msg_fields  = ['SiteName', 'CloudComputeService', 'Month', 'Year', 
-                             'GlobalUserName', 'VO', 'VOGroup', 'VORole',
-                             'Status', 'CloudType', 'ImageId', 'EarliestStartTime', 
-                             'LatestStartTime', 'WallDuration', 'CpuDuration', 'CpuCount',
-                             'NetworkInbound', 'NetworkOutbound', 'Memory', 'Disk', 
-                             'BenchmarkType', 'Benchmark', 'NumberOfVMs']
-        
+        self._msg_fields = ['SiteName', 'CloudComputeService', 'Month', 'Year',
+                            'GlobalUserName', 'VO', 'VOGroup', 'VORole',
+                            'Status', 'CloudType', 'ImageId',
+                            'EarliestStartTime', 'LatestStartTime',
+                            'WallDuration', 'CpuDuration', 'CpuCount',
+                            'NetworkInbound', 'NetworkOutbound',
+                            'Memory', 'Disk',
+                            'BenchmarkType', 'Benchmark', 'NumberOfVMs']
+
         # This list specifies the information that goes in the database.
         self._db_fields = self._msg_fields
         self._all_fields = self._db_fields
-        
+
         self._ignored_fields = ['UpdateTime']
-        
+
         # Fields which will have an integer stored in them
         self._int_fields = ['Month', 'Year', 'WallDuration', 'CpuDuration',
                             'CpuCount', 'NetworkInbound', 'NetworkOutbound',
@@ -55,5 +58,3 @@ class CloudSummaryRecord(Record):
         
         self._float_fields = ['Benchmark']
         self._datetime_fields = ['EarliestStartTime', 'LatestStartTime']
-    
-        

--- a/apel/db/records/cloud_summary.py
+++ b/apel/db/records/cloud_summary.py
@@ -49,9 +49,9 @@ class CloudSummaryRecord(Record):
         self._ignored_fields = ['UpdateTime']
         
         # Fields which will have an integer stored in them
-        self._int_fields = [ 'Month', 'Year', 'WallDuration', 'CpuDuration', 
-                             'NetworkInbound', 'NetworkOutbound',
-                             'Memory', 'Disk', 'NumberOfVMs']
+        self._int_fields = ['Month', 'Year', 'WallDuration', 'CpuDuration',
+                            'CpuCount', 'NetworkInbound', 'NetworkOutbound',
+                            'Memory', 'Disk', 'NumberOfVMs']
         
         self._float_fields = ['Benchmark']
         self._datetime_fields = ['EarliestStartTime', 'LatestStartTime']

--- a/test/test_cloud_summary.py
+++ b/test/test_cloud_summary.py
@@ -25,6 +25,7 @@ EarliestStartTime: 1318840264
 LatestStartTime: 1318840264
 WallDuration: None
 CpuDuration: None
+CpuCount: 4
 NetworkInbound: 0
 NetworkOutbound: 0
 Memory: 512

--- a/test/test_cloud_summary.py
+++ b/test/test_cloud_summary.py
@@ -3,11 +3,11 @@ import unittest
 from apel.db.records import CloudSummaryRecord
 
 
-class CloudRecordTest(unittest.TestCase):
+class CloudSummaryRecordTest(unittest.TestCase):
     '''
     Test case for CloudSummaryRecord
     '''
-    
+
     def setUp(self):
         self._msg1 = '''
 SiteName: CESNET
@@ -33,9 +33,9 @@ BenchmarkType: Si2k
 Benchmark: 1006.3
 NumberOfVMs: 1
 '''
-        
+
         self._values1 = {'SiteName': 'CESNET',
-                        'CloudComputeService': 'OpenNebula Service A', 
+                        'CloudComputeService': 'OpenNebula Service A',
                         'Status': 'completed',
                         'CloudType': 'OpenNebula',
                         'NetworkInbound': 0,
@@ -46,24 +46,22 @@ NumberOfVMs: 1
                         'Benchmark': 1006.3,
                         'NumberOfVMs': 1
                         }
-        
-        
+
         self.cases = {}
         self.cases[self._msg1] = self._values1
 
     def test_load_from_msg(self):
-        
+
         for msg in self.cases.keys():
-        
+
             cr = CloudSummaryRecord()
             cr.load_from_msg(msg)
-            
+
             cont = cr._record_content
-        
+
             for key in self.cases[msg].keys():
                 self.assertEqual(cont[key], self.cases[msg][key], "%s != %s for key %s" % (cont[key], self.cases[msg][key], key))
-        
-        
+
     def test_mandatory_fields(self):
         record = CloudSummaryRecord()
         record.set_field('SiteName', 'MySite')
@@ -77,11 +75,11 @@ NumberOfVMs: 1
         record.set_field('CloudType', 'OpenStack')
         record.set_field('ImageId', 'img-01')
         record.set_field('NumberOfVMs', 1)
-        
+
         try:
             record._check_fields()
         except Exception, e:
-            self.fail('_check_fields method failed: %s [%s]' % (str(e), str(type(e))))
+            self.fail('_check_fields method failed: %s [%s]' % (e, type(e)))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Resolves #103.

This PR updates the cloud accounting to include CPU count in the summaries that are sent to the portal. 

- The update schema (from adding support for schema v0.4) has been updated to include CPU count.
- I've even remembered to alter the number of arguments in the procedure call.
- Added it to `self._msg_fields` which is the key field for defining the unloaded messages.