### PR TITLE
Add extra PBS test case to cover odd processors

### DIFF
--- a/test/test_pbs.py
+++ b/test/test_pbs.py
@@ -27,6 +27,11 @@ class ParserPBSTest(unittest.TestCase):
              'Resource_List.cput=800:00:00 Resource_List.neednodes=1:ppn=8 Resource_List.nodect=1 Resource_List.nodes=1:ppn=8 '
              'Resource_List.opsys=sl5 Resource_List.pcput=96:00:00 Resource_List.walltime=96:00:00 session=7428 end=1317427530 '
              'Exit_status=0 resources_used.cput=00:00:00 resources_used.mem=0kb resources_used.vmem=0kb resources_used.walltime=00:00:00'),
+            # Awkward version that requests 8 proccessors but only seems to be
+            # assigned one and doesn't contain "total_execution_slots".
+            ('02/15/2015 00:00:26;E;2503618.grid.desu.cf;user=atlasprd005 group=atlasprd jobname=cream_454853282 queue=mcore ctime=1423949785 qtime=1423949785 etime=1423949785 start=1423949810 owner=atlasprd005@grid-cr4.desy.de '
+             'exec_host=wn09.desu.cf/2 Resource_List.cput=60:00:00 Resource_List.neednodes=1:ppn=8 Resource_List.nodect=1 Resource_List.nodes=1:ppn=8 Resource_List.pcput=60:00:00 Resource_List.walltime=90:00:00 session=22081 end=1423954826 '
+             'Exit_status=0 resources_used.cput=10:00:27 resources_used.mem=11685192kb resources_used.vmem=16983240kb resources_used.walltime=01:23:36'),
             ('11/30/2015 15:39:52;E;24940336.b0;user=atlaspt5 group=atlaspt jobname=cream_830820758 queue=atlas ctime=1448913907 qtime=1448913907 et'
              'ime=1448913907 start=1448914025 owner=atlaspt5@bugaboo-hep.westgrid.ca exec_host=b341/2 Resource_List.file=15gb Resource_List.neednode'
              's=1 Resource_List.nodect=1 Resource_List.nodes=1 Resource_List.pmem=2000mb Resource_List.pvmem=4000mb Resource_List.vmem=4000mb Resour'
@@ -71,6 +76,11 @@ class ParserPBSTest(unittest.TestCase):
             ("21010040.lcgbatch01.gridpp.rl.ac.uk", "plhcb010", "prodlhcb", 0,
              0, datetime.datetime.utcfromtimestamp(1317427530),
              datetime.datetime.utcfromtimestamp(1317427530), 0, 0, 1, 8),
+            ("2503618.grid.desu.cf", "atlasprd005", "atlasprd",
+             01 * 3600 + 23 * 60 + 36, 10 * 3600 + 27,
+             datetime.datetime.utcfromtimestamp(1423949810),
+             datetime.datetime.utcfromtimestamp(1423954826), 11685192, 16983240,
+             1, 1),
             ("24940336.b0", "atlaspt5", "atlaspt", 3*3600+32*60+47,
              3*3600+32*60+2, datetime.datetime.utcfromtimestamp(1448914025),
              datetime.datetime.utcfromtimestamp(1448926792), 2574308, 4032516,


### PR DESCRIPTION
- Add extra PBS test to cover the case where more than one processor is
  requested but only one seems to be assigned and there is no
  total_execution_slots in the output. This is hopefully no longer a
  common case with the addition of the execution slots in later versions.
  It was never clear exactly how this situation should be handled.