### PR TITLE
Replace backslashes with implicit line continuation

### DIFF
--- a/apel/common/datetime_utils.py
+++ b/apel/common/datetime_utils.py
@@ -104,12 +104,12 @@ def iso2seconds(isoduration):
             intvals.append(0)
 
     # ignore group 0 ("P") and group 5 ("T")
-    seconds = intvals[1] * 31536000 + \
-            intvals[2] * 2628000 + \
-            intvals[3] * 604800 + \
-            intvals[4] * 86400 + \
-            intvals[6] * 3600 + \
-            intvals[7] * 60 + \
-            intvals[8] 
-    
+    seconds = (intvals[1] * 31536000 +
+               intvals[2] * 2628000 +
+               intvals[3] * 604800 +
+               intvals[4] * 86400 +
+               intvals[6] * 3600 +
+               intvals[7] * 60 +
+               intvals[8])
+
     return seconds

--- a/apel/db/backends/mysql.py
+++ b/apel/db/backends/mysql.py
@@ -20,17 +20,17 @@ Created on 27 Oct 2011
 
 
 from apel.db import ApelDbException
-from apel.db.records import BlahdRecord, \
-                            CloudRecord, \
-                            CloudSummaryRecord, \
-                            EventRecord, \
-                            GroupAttributeRecord, \
-                            JobRecord, \
-                            NormalisedSummaryRecord, \
-                            ProcessedRecord, \
-                            StorageRecord, \
-                            SummaryRecord, \
-                            SyncRecord
+from apel.db.records import (BlahdRecord,
+                             CloudRecord,
+                             CloudSummaryRecord,
+                             EventRecord,
+                             GroupAttributeRecord,
+                             JobRecord,
+                             NormalisedSummaryRecord,
+                             ProcessedRecord,
+                             StorageRecord,
+                             SummaryRecord,
+                             SyncRecord)
 import MySQLdb.cursors
 import datetime
 import logging

--- a/test/test_datetime_utils.py
+++ b/test/test_datetime_utils.py
@@ -1,5 +1,4 @@
-from apel.common import valid_from, valid_until, parse_timestamp, \
-    iso2seconds
+from apel.common import valid_from, valid_until, parse_timestamp, iso2seconds
 import unittest
 import datetime
 


### PR DESCRIPTION
Replace backslashes used for line continuation in Python code with implicit line continuation using parentheses as the former style is discouraged and is fragile.

There are places that use backslashes in shell code, but that's a separate issue.