### PR TITLE
Add a test for loading cloud messages (from the APEL message format) to the database

### DIFF
--- a/apel/db/backends/mysql.py
+++ b/apel/db/backends/mysql.py
@@ -49,7 +49,7 @@ class ApelMysqlDb(object):
                     JobRecord   : 'VJobRecords',
                     BlahdRecord : 'BlahdRecords',
                     SyncRecord  : 'SyncRecords',
-                    CloudRecord : 'CloudRecords',
+                    CloudRecord : 'VCloudRecords',
                     CloudSummaryRecord : 'VCloudSummaries',
                     NormalisedSummaryRecord : 'VNormalisedSummaries',
                     ProcessedRecord : 'VProcessedFiles',

--- a/schemas/cloud.sql
+++ b/schemas/cloud.sql
@@ -211,7 +211,7 @@ DELIMITER ;
 
 -- -----------------------------------------------------------------------------
 -- Sites
-
+DROP TABLE IF EXISTS Sites;
 CREATE TABLE Sites (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY
  ,  name VARCHAR(255) NOT NULL
@@ -237,7 +237,7 @@ DELIMITER ;
 
 -- -----------------------------------------------------------------------------
 -- CloudComputeService
-
+DROP TABLE IF EXISTS CloudComputeServices;
 CREATE TABLE CloudComputeServices (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY
  ,  name VARCHAR(255) NOT NULL
@@ -263,7 +263,7 @@ DELIMITER ;
 
 -- -----------------------------------------------------------------------------
 -- DNs
-
+DROP TABLE IF EXISTS DNs;
 CREATE TABLE DNs (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY
  ,  name VARCHAR(255) NOT NULL

--- a/test/test_mysql.py
+++ b/test/test_mysql.py
@@ -80,6 +80,13 @@ class MysqlTest(unittest.TestCase):
         self.assertEqual([item in items_out for item in items_in].count(True), len(items_in))
 
     def test_load_and_get_cloud(self):
+        '''
+        Test a CloudV0.2/0.4 message can be loaded into the database.
+
+        It currently can't test for pre/post database load equality
+        as the two are currently not the same for V0.2.
+        i.e Benchmark 'None', which gets saved a set to 0.0
+        '''
         schema_path = os.path.abspath(os.path.join('..', 'schemas',
                                                    'cloud.sql'))
         schema_handle = open(schema_path)
@@ -109,6 +116,23 @@ class MysqlTest(unittest.TestCase):
             self.db.load_records(record_list, source='testDN')
         except apel.db.apeldb.ApelDbException as err:
             self.fail(err.message)
+
+        # this code block would check for equality between the message passed
+        # to the database and the message retrieved from the database.
+        # but at the moment they are fundementally unequal, for example
+        # a cloud 0.2 message has Benchmark 'None', which gets saved to 0.0
+        # in the database
+
+        # records_out = self.db.get_records(apel.db.records.cloud.CloudRecord)
+        # # record_out_list is a list of lists, i.e. [[record0.2],[[record0.4]]
+        # record_out_list = list(records_out)
+        # items_out = []
+        # for record in record_out_list[0]:
+        #     items_out += record._record_content.items()
+        # Check that items_in is a subset of items_out
+        # Can't use 'all()' rather than comparing the length as Python 2.4
+        # self.assertEqual([item in items_out for item in items_in].count(True),
+        #                   len(items_in))
 
     def test_mixed_load(self):
         """

--- a/test/test_mysql.py
+++ b/test/test_mysql.py
@@ -85,7 +85,7 @@ class MysqlTest(unittest.TestCase):
 
         It currently can't test for pre/post database load equality
         as the two are currently not the same for V0.2.
-        i.e Benchmark 'None', which gets saved a set to 0.0
+        i.e Benchmark 'None', which gets set to 0.0
         '''
         schema_path = os.path.abspath(os.path.join('..', 'schemas',
                                                    'cloud.sql'))


### PR DESCRIPTION
This test, whilst passing and not adding to the code coverage, does reveal database warnings that become failures with stricter `sql_mode` settings, as referenced in #128.

This test will ensure the fix for #128 does not break the cloud loader, i.e by trying to pass a `NULL` benchmark to the database while `Benchmark` is a `NOT NULL` field), which is currently not caught by the unit tests.

Changes to `apel/db/backends/mysql.py`:
- will hopefully allow future equality testing of coud records pre and post database load in a similar fashion to job records by allowing `_get_records` to work for cloud records  
- it seems like `_get_records` only used in tests (i.e. `MYSQL_TABLES` is only mentioned in
  `_get_records`/`get_records`, which are in turn only called in testing