### PR TITLE
Prevent compiled python files from being installed by the RPM

### DIFF
--- a/apel.spec
+++ b/apel.spec
@@ -177,8 +177,9 @@ exit 0
 %_datadir/apel/update-1.5.1-1.6.0.sql
 %_datadir/apel/update-1.6.0-next.sql
 
-# Use wildcard to match .py, .pyc, and .pyo
-%attr(755,root,root) %_datadir/apel/msg_status.py*
+%attr(755,root,root) %_datadir/apel/msg_status.py
+%exclude %_datadir/apel/msg_status.pyc
+%exclude %_datadir/apel/msg_status.pyo
 
 # Directories for logs, PID files
 %dir %{_localstatedir}/log/apel


### PR DESCRIPTION
- Replace wildcard match with explicit excluding of `.pyc`/`.pyo` files

- The `.pyc`/`.pyo` files are auto-generated by `rpmbuild` so we can't stop them being generated and we cant just remove the wildcard because `rpmbuild` complains the `.pyc`/`.pyo` are present but not added to the RPM. So we need to explicitly exclude them from the RPM.

- 'exclude' is not the most documented spec file directive