### PR TITLE
Remove LSF version restriction

### DIFF
--- a/apel/parsers/lsf.py
+++ b/apel/parsers/lsf.py
@@ -108,34 +108,27 @@ class LSFParser(Parser):
         else:
             nnodes = 0
             ncores = 0
-        
-        mapping_lsf = {'Site'          : lambda x: self.site_name,
-                       'JobName'       : lambda x: x[3],
-                       'LocalUserID'   : lambda x: x[11],
-                       'LocalUserGroup': lambda x: "",
-                       'WallDuration'  : lambda x: int(host_factor * (int(x[2]) - int(x[10]))),
-                       'CpuDuration'   : lambda x: int(round(host_factor * (float(x[28+offset]) + float(x[29+offset])))),
-                       'StartTime'     : lambda x: int(x[10]),
-                       'StopTime'      : lambda x: int(x[2]),
-                       'Infrastructure': lambda x: "APEL-CREAM-LSF",
-                       'Queue'         : lambda x: x[12],
-                       'MachineName'   : lambda x: self.machine_name,
-                       'MemoryReal'    : lambda x: int(x[54+offset]) > 0 and int(x[54+offset]) or 0,
-                       'MemoryVirtual' : lambda x: int(x[55+offset]) > 0 and int(x[55+offset]) or 0,
-                       'Processors'    : lambda x: ncores,
-                       'NodeCount'     : lambda x: nnodes}
-        
-        mapping = {'5': mapping_lsf,
-                   '6': mapping_lsf,
-                   '7': mapping_lsf,
-                   '8': mapping_lsf,
-                   '9': mapping_lsf}
-        
-        version = items[1][0]
+
+        mapping = {'Site'          : lambda x: self.site_name,
+                   'JobName'       : lambda x: x[3],
+                   'LocalUserID'   : lambda x: x[11],
+                   'LocalUserGroup': lambda x: "",
+                   'WallDuration'  : lambda x: int(host_factor * (int(x[2]) - int(x[10]))),
+                   'CpuDuration'   : lambda x: int(round(host_factor * (float(x[28+offset]) + float(x[29+offset])))),
+                   'StartTime'     : lambda x: int(x[10]),
+                   'StopTime'      : lambda x: int(x[2]),
+                   'Infrastructure': lambda x: "APEL-CREAM-LSF",
+                   'Queue'         : lambda x: x[12],
+                   'MachineName'   : lambda x: self.machine_name,
+                   'MemoryReal'    : lambda x: int(x[54+offset]) > 0 and int(x[54+offset]) or 0,
+                   'MemoryVirtual' : lambda x: int(x[55+offset]) > 0 and int(x[55+offset]) or 0,
+                   'Processors'    : lambda x: ncores,
+                   'NodeCount'     : lambda x: nnodes}
+
         data = {}
-    
-        for key in mapping[version]:
-            data[key] = mapping[version][key](items)
+
+        for key in mapping:
+            data[key] = mapping[key](items)
 
         # Input checking
         if data['CpuDuration'] < 0:

--- a/test/test_lsf.py
+++ b/test/test_lsf.py
@@ -119,16 +119,6 @@ class ParserLSFTest(unittest.TestCase):
                 ' 87722 0 0 0 -1 0 0 0 0 0 -1 "" "default" 0 1 "" "" 0 310424 339112 "" "" ""')
         
         self.assertRaises(IndexError, self.parser.parse, line)
-    
-    def test_invalid_version(self):
-        # unsupported version
-        line = ('"JOB_FINISH" "10.1" 1089407406 699195 283 33554482 1 1089290023 0 0 1089406862 '
-                '"raortega" "8nm" "" "" "" "lxplus015" "prog/step3c" "" "/afs/cern.ch/user/r/raortega/log/bstep3c-362.txt" '
-                '"/afs/cern.ch/user/r/raortega/log/berr-step3c-362.txt" "1089290023.699195" 0 1 "tbed0079" 64 3.3 "" '
-                '"/afs/cern.ch/user/r/raortega/prog/step3c/startEachset.pl362 7 8" 277.210000 17.280000 0 0 -1 0 0 927804'
-                ' 87722 0 0 0 -1 0 0 0 0 0 -1 "" "default" 0 1 "" "" 0 310424 339112 "" "" ""')
-        
-        self.assertRaises(KeyError, self.parser.parse, line)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Resolves #129.

- Remove LSF version restriction from LSF parser (where a TypeError would be raised if there was an unexpected version in the accounting log) as LSF has been well behaved over a number of major versions, it causes problems for users trying to upgrade to newer versions that haven't been tested, and we don't check versions in any other parser. This should remove the burden of updating the version mapping whenever a new LSF version is released.
- Remove unittest for invalid LSF version as version is no longer checked.

Site from GGUS ticket (see issue #129) has used this updated parser successfully.