### PR TITLE
Add type checking to float and datetime fields of records

### DIFF
--- a/apel/db/records/cloud.py
+++ b/apel/db/records/cloud.py
@@ -78,12 +78,11 @@ class CloudRecord(Record):
             vo = 'None'
 
         if self._record_content['Benchmark'] is None:
-            # If Benchmark is not present in the original record
-            # the Record class level type checking will set
-            # it to None. We can't pass None as a Benchmark
-            # as the filed is NOT NULL in the database.
-            # So we set it to something meaningful. In this
-            # case the empty 0.0
+            # If Benchmark is not present in the original record the
+            # parent Record class level type checking will set it to
+            # None. We can't pass None as a Benchmark as the field is
+            # NOT NULL in the database, so we set it to something
+            # meaningful. In this case the float 0.0.
             self._record_content['Benchmark'] = 0.0
             
             

--- a/apel/db/records/cloud.py
+++ b/apel/db/records/cloud.py
@@ -76,6 +76,16 @@ class CloudRecord(Record):
             group = 'None'
         if vo is None:
             vo = 'None'
+
+        if self._record_content['Benchmark'] is None:
+            # If Benchmark is not present in the original record
+            # the Record class level type checking will set
+            # it to None. We can't pass None as a Benchmark
+            # as the filed is NOT NULL in the database.
+            # So we set it to something meaningful. In this
+            # case the empty 0.0
+            self._record_content['Benchmark'] = 0.0
+            
             
         self._record_content['VORole'] = role
         self._record_content['VOGroup'] = group

--- a/apel/db/records/job.py
+++ b/apel/db/records/job.py
@@ -146,12 +146,12 @@ class JobRecord(Record):
         Check for the validity of the ScalingFactorUnit and ScalingFactor fields.
         We accept neither field included or both.  If only one of the fields is 
         included, it doesn't really make sense so we reject it.
-    
+
         We expect that:
-           - As ServiceLevel is a float field,
-             a null sf has been converted to None.
-           - As ServiceLevelType is a msg field,
-             a null sf has been converted to the string 'None'.
+        - as ServiceLevel is a float field,
+          a null ScalingFactor is passed in as the null object None.
+        - as ServiceLevelType is a msg field,
+          a null ScalingFactorUnit is passed in as the string 'None'.
         '''
         if sf == None:
             if sfu != 'None':

--- a/apel/db/records/job.py
+++ b/apel/db/records/job.py
@@ -147,9 +147,13 @@ class JobRecord(Record):
         We accept neither field included or both.  If only one of the fields is 
         included, it doesn't really make sense so we reject it.
     
-        We expect that all null values have been converted to the string 'None'.
+        We expect that:
+           - As ServiceLevel is a float field,
+             a null sf has been converted to None.
+           - As ServiceLevelType is a msg field,
+             a null sf has been converted to the string 'None'.
         '''
-        if sf == 'None':
+        if sf == None:
             if sfu != 'None':
                 raise InvalidRecordException('Unit but not value supplied for ScalingFactor.')
             else:

--- a/apel/db/records/job.py
+++ b/apel/db/records/job.py
@@ -153,7 +153,7 @@ class JobRecord(Record):
         - as ServiceLevelType is a msg field,
           a null ScalingFactorUnit is passed in as the string 'None'.
         '''
-        if sf == None:
+        if sf is None:
             if sfu != 'None':
                 raise InvalidRecordException('Unit but not value supplied for ScalingFactor.')
             else:

--- a/apel/db/records/record.py
+++ b/apel/db/records/record.py
@@ -331,9 +331,8 @@ class Record(object):
                 value = contents[key]
             except KeyError:
                 value = None
-                    
-            # check if we have an integer in this field
-            # by trying to cast value to an int
+
+            # Check if we have an integer by trying to cast to an int.
             try:
                 value = int(value)
             except (ValueError, TypeError):
@@ -346,15 +345,14 @@ class Record(object):
                     raise InvalidRecordException("Int field " + key + 
                                     " doesn't contain an integer.")
 
-        # Change the null values for floats to None (not 'None'!) -> NULL in the DB.
+        # Change null values for floats to the null object -> NULL in the DB.
         for key in self._float_fields:
             try:
                 value = contents[key]
             except KeyError:
                 value = None
 
-            # check if we have an float in this field
-            # by trying to cast value to a float
+            # Check if we have an float by trying to cast to a float.
             try:
                 value = float(value)
             except (ValueError, TypeError):
@@ -367,17 +365,17 @@ class Record(object):
                     raise InvalidRecordException("Decimal field " + key +
                                     " doesn't contain a float.")
 
-       # Change the null values for Datetimes to None (not 'None'!) -> NULL in the DB.
+        # Change null values for Datetimes to the null object -> NULL in the DB.
         for key in self._datetime_fields:
             try:
                 value = contents[key]
             except KeyError:
                 value = None
 
-            # check if we have an datetime in this field
-            # have to check this slightly differently than a int/float
-            # as there doesn't seem to be a nice function to attempt
-            # to cast a object to a datetime
+            # Check if we have a datetime in this field.
+            # We have to check this slightly differently than an int/float
+            # as there doesn't seem to be a nice function to attempt to
+            # cast an object to a datetime.
             if not isinstance(value, datetime):
                 if key in self._mandatory_fields:
                     raise InvalidRecordException("Mandatory datetime field " + key +

--- a/apel/db/records/record.py
+++ b/apel/db/records/record.py
@@ -333,6 +333,7 @@ class Record(object):
                 value = None
                     
             # check if we have an integer in this field
+            # by trying to cast value to an int
             try:
                 value = int(value)
             except (ValueError, TypeError):
@@ -344,3 +345,45 @@ class Record(object):
                 elif value is not None:
                     raise InvalidRecordException("Int field " + key + 
                                     " doesn't contain an integer.")
+
+        # Change the null values for floats to None (not 'None'!) -> NULL in the DB.
+        for key in self._float_fields:
+            try:
+                value = contents[key]
+            except KeyError:
+                value = None
+
+            # check if we have an float in this field
+            # by trying to cast value to a float
+            try:
+                value = float(value)
+            except (ValueError, TypeError):
+                if key in self._mandatory_fields:
+                    raise InvalidRecordException("Mandatory decimal field " + key +
+                                    " doesn't contain a float.")
+                elif check_for_null(value):
+                    contents[key] = None
+                elif value is not None:
+                    raise InvalidRecordException("Decimal field " + key +
+                                    " doesn't contain a float.")
+
+       # Change the null values for Datetimes to None (not 'None'!) -> NULL in the DB.
+        for key in self._datetime_fields:
+            try:
+                value = contents[key]
+            except KeyError:
+                value = None
+
+            # check if we have an datetime in this field
+            # have to check this slightly differently than a int/float
+            # as there doesn't seem to be a nice function to attempt
+            # to cast a object to a datetime
+            if not isinstance(value, datetime):
+                if key in self._mandatory_fields:
+                    raise InvalidRecordException("Mandatory datetime field " + key +
+                                   " doesn't contain a datetime.")
+                elif check_for_null(value):
+                    contents[key] = None
+                elif value is not None:
+                    raise InvalidRecordException("Datetime field " + key +
+                                    " doesn't contain an datetime.")

--- a/test/test_cloud_record.py
+++ b/test/test_cloud_record.py
@@ -175,7 +175,7 @@ CloudType: OpenNebula
         self.cases[self._msg3] = self._values3
 
     def test_load_from_msg_value_check(self):
-        """Check self._values# is a subset of the CloudRecord object generated from self._msg#."""
+        """Check for correct values in CloudRecords generated from messages."""
         for msg in self.cases.keys():
         
             cr = CloudRecord()
@@ -187,7 +187,7 @@ CloudType: OpenNebula
                 self.assertEqual(cont[key], self.cases[msg][key], "%s != %s for key %s" % (cont[key], self.cases[msg][key], key))
 
     def test_load_from_msg_type_check(self):
-        """Check the fields of a loaded message are the correct type."""
+        """Check the fields of a parsed message are of the correct type."""
         for msg in self.cases.keys():
 
             cr = CloudRecord()
@@ -195,30 +195,30 @@ CloudType: OpenNebula
 
             for key in cr._int_fields:
                 value = cr._record_content[key]
-                # check the value we are going to be passing to MySQL is an integer or None
-                # MySQL 5.6.X rejects the value otherwise, whereas 5.1.X would have
-                # interpreted it as the 0
+                # Check the value we are going to be passing to MySQL
+                # is an integer or None. MySQL 5.6.x rejects the value
+                # otherwise, whereas 5.1.x interprets it as integer 0.
                 valid_value = isinstance(value, int) or value is None
-                # The 'repr' expression shows the quote marks if value is a string
                 self.assertTrue(valid_value, 'Integer %s with value: %s\n%s' % (key, repr(value), msg))
+                # Use 'repr' to show quote marks if value is a string.
 
             for key in cr._float_fields:
                 value = cr._record_content[key]
-                # check the value we are going to be passing to MySQL is an float or None
-                # MySQL 5.6.X rejects the value otherwise, whereas 5.1.X would have
-                # interpreted it as 0.00
+                # Check the value we are going to be passing to MySQL
+                # is a float or None. MySQL 5.6.x rejects the value
+                # otherwise, whereas 5.1.x interprets it as 0.00.
                 valid_value = isinstance(value, float) or value is None
-                # The 'repr' expression shows the quote marks if value is a string
                 self.assertTrue(valid_value, 'Decimal %s with value: %s\n%s' % (key, repr(value), msg))
+                # Use 'repr' to show quote marks if value is a string.
 
             for key in cr._datetime_fields:
                 value = cr._record_content[key]
-                # check the value we are going to be passing to MySQL is an datetime or None
-                # MySQL 5.6.X rejects the value otherwise, whereas 5.1.X would have
-                # interpreted it as the zero time stamp
+                # Check the value we are going to be passing to MySQL
+                # is a datetime or None. MySQL 5.6.x rejects the value
+                # otherwise, whereas 5.1.x interprets it as a zero timestamp.
                 valid_value = isinstance(value, datetime) or value is None
-                # The 'repr' expression shows the quote marks if value is a string
                 self.assertTrue(valid_value, 'Datetime %s with value: %s\n%s' % (key, repr(value), msg))
+                # Use 'repr' to show quote marks if value is a string.
 
     def test_mandatory_fields(self):
         record = CloudRecord()

--- a/test/test_cloud_record.py
+++ b/test/test_cloud_record.py
@@ -174,8 +174,8 @@ CloudType: OpenNebula
         self.cases[self._msg2] = self._values2
         self.cases[self._msg3] = self._values3
 
-    def test_load_from_msg(self):
-        
+    def test_load_from_msg_value_check(self):
+        """Check self._values# is a subset of the CloudRecord object generated from self._msg#."""
         for msg in self.cases.keys():
         
             cr = CloudRecord()

--- a/test/test_cloud_record.py
+++ b/test/test_cloud_record.py
@@ -166,7 +166,7 @@ CloudType: OpenNebula
                          'PublicIPCount': None,
                          'Memory': 512,
                          'BenchmarkType': 'None',
-                         'Benchmark': None,
+                         'Benchmark': 0.0,
                          'ImageId': '\'scilin6\'',
                          'CloudType': 'OpenNebula'}
         self.cases = {}

--- a/test/test_cloud_record.py
+++ b/test/test_cloud_record.py
@@ -1,5 +1,4 @@
 import unittest
-
 from datetime import datetime
 
 from apel.db.records import CloudRecord
@@ -199,8 +198,9 @@ CloudType: OpenNebula
                 # is an integer or None. MySQL 5.6.x rejects the value
                 # otherwise, whereas 5.1.x interprets it as integer 0.
                 valid_value = isinstance(value, int) or value is None
-                self.assertTrue(valid_value, 'Integer %s with value: %s\n%s' % (key, repr(value), msg))
                 # Use 'repr' to show quote marks if value is a string.
+                self.assertTrue(valid_value, 'Integer %s with value: %s\n%s' %
+                                (key, repr(value), msg))
 
             for key in cr._float_fields:
                 value = cr._record_content[key]
@@ -208,8 +208,9 @@ CloudType: OpenNebula
                 # is a float or None. MySQL 5.6.x rejects the value
                 # otherwise, whereas 5.1.x interprets it as 0.00.
                 valid_value = isinstance(value, float) or value is None
-                self.assertTrue(valid_value, 'Decimal %s with value: %s\n%s' % (key, repr(value), msg))
                 # Use 'repr' to show quote marks if value is a string.
+                self.assertTrue(valid_value, 'Decimal %s with value: %s\n%s' %
+                                (key, repr(value), msg))
 
             for key in cr._datetime_fields:
                 value = cr._record_content[key]
@@ -217,8 +218,9 @@ CloudType: OpenNebula
                 # is a datetime or None. MySQL 5.6.x rejects the value
                 # otherwise, whereas 5.1.x interprets it as a zero timestamp.
                 valid_value = isinstance(value, datetime) or value is None
-                self.assertTrue(valid_value, 'Datetime %s with value: %s\n%s' % (key, repr(value), msg))
                 # Use 'repr' to show quote marks if value is a string.
+                self.assertTrue(valid_value, 'Datetime %s with value: %s\n%s' %
+                                (key, repr(value), msg))
 
     def test_mandatory_fields(self):
         record = CloudRecord()

--- a/test/test_cloud_record.py
+++ b/test/test_cloud_record.py
@@ -166,7 +166,7 @@ CloudType: OpenNebula
                          'PublicIPCount': None,
                          'Memory': 512,
                          'BenchmarkType': 'None',
-                         'Benchmark': 'None',
+                         'Benchmark': None,
                          'ImageId': '\'scilin6\'',
                          'CloudType': 'OpenNebula'}
         self.cases = {}

--- a/test/test_cloud_record.py
+++ b/test/test_cloud_record.py
@@ -1,5 +1,7 @@
 import unittest
 
+from datetime import datetime
+
 from apel.db.records import CloudRecord
 
 
@@ -183,8 +185,41 @@ CloudType: OpenNebula
         
             for key in self.cases[msg].keys():
                 self.assertEqual(cont[key], self.cases[msg][key], "%s != %s for key %s" % (cont[key], self.cases[msg][key], key))
-        
-        
+
+    def test_load_from_msg_type_check(self):
+        """Check the fields of a loaded message are the correct type."""
+        for msg in self.cases.keys():
+
+            cr = CloudRecord()
+            cr.load_from_msg(msg)
+
+            for key in cr._int_fields:
+                value = cr._record_content[key]
+                # check the value we are going to be passing to MySQL is an integer or None
+                # MySQL 5.6.X rejects the value otherwise, whereas 5.1.X would have
+                # interpreted it as the 0
+                valid_value = isinstance(value, int) or value is None
+                # The 'repr' expression shows the quote marks if value is a string
+                self.assertTrue(valid_value, 'Integer %s with value: %s\n%s' % (key, repr(value), msg))
+
+            for key in cr._float_fields:
+                value = cr._record_content[key]
+                # check the value we are going to be passing to MySQL is an float or None
+                # MySQL 5.6.X rejects the value otherwise, whereas 5.1.X would have
+                # interpreted it as 0.00
+                valid_value = isinstance(value, float) or value is None
+                # The 'repr' expression shows the quote marks if value is a string
+                self.assertTrue(valid_value, 'Decimal %s with value: %s\n%s' % (key, repr(value), msg))
+
+            for key in cr._datetime_fields:
+                value = cr._record_content[key]
+                # check the value we are going to be passing to MySQL is an datetime or None
+                # MySQL 5.6.X rejects the value otherwise, whereas 5.1.X would have
+                # interpreted it as the zero time stamp
+                valid_value = isinstance(value, datetime) or value is None
+                # The 'repr' expression shows the quote marks if value is a string
+                self.assertTrue(valid_value, 'Datetime %s with value: %s\n%s' % (key, repr(value), msg))
+
     def test_mandatory_fields(self):
         record = CloudRecord()
         record.set_field('VMUUID', 'host.example.org/cr/87912469269276')

--- a/test/test_mysql.py
+++ b/test/test_mysql.py
@@ -105,10 +105,15 @@ class MysqlTest(unittest.TestCase):
         cloud4 = apel.db.records.cloud.CloudRecord()
         cloud4.load_from_msg(CLOUD4)
 
+        # Test a BenchmarkType/Benchmark - less Cloud v0.4 Record
+        cloud4_nb = apel.db.records.cloud.CloudRecord()
+        cloud4_nb.load_from_msg(CLOUD4_NULL_BENCHMARKS)
+
         items_in = cloud2._record_content.items()
         items_in += cloud4._record_content.items()
+        items_in += cloud4_nb._record_content.items()
 
-        record_list = [cloud2, cloud4]
+        record_list = [cloud2, cloud4, cloud4_nb]
 
         # load_records changes the 'cloud' cloud record as it calls _check_fields
         # which adds placeholders to empty fields
@@ -251,6 +256,35 @@ Memory: 512
 Disk: 0
 BenchmarkType: Si2k
 Benchmark: 200
+StorageRecordId: NULL
+ImageId: 1
+CloudType: Cloud Technology 2
+'''
+
+# A Cloud V0.4 Record, but with NULL Benchmark / BenchmarkType fields
+CLOUD4_NULL_BENCHMARKS = '''VMUUID: 12346 Site2 Accounting Test
+SiteName: Site2
+CloudComputeService: Cloud Technology 2 Instance 1
+MachineName: Accounting Test 2
+LocalUserId: 1
+LocalGroupId: 1
+GlobalUserName: /DC=XX/DC=XX/O=XX/CN=XX
+FQAN: /ops/Role=NULL/Capability=NULL
+Status: started
+StartTime: 1343362825
+EndTime: NULL
+SuspendDuration: NULL
+WallDuration: 1583876
+CpuDuration: 438
+CpuCount: 1
+NetworkType: NULL
+NetworkInbound: NULL
+NetworkOutbound: NULL
+PublicIPCount: 1
+Memory: 512
+Disk: 0
+BenchmarkType: NULL
+Benchmark: NULL
 StorageRecordId: NULL
 ImageId: 1
 CloudType: Cloud Technology 2


### PR DESCRIPTION
Resolves #128 

`Record._check_fields()` now checks fields listed in `self._float_fields` and `self._datetime_fields`  are the appropriate type, i.e. `float` or `datetime` in a similar fashion to how `self._int_fields` are currently handled. In the case of `self._float_fields` it will try and cast the input to a `float` if it is not already.

This results in properly typed fields or `None` to be passed to the database, rather than properly typed fields or the string `'None'`. 

This fixes the problem that MySQL 5.6.X has strict type checking and wont do the type casts that 5.1.X would.

The change to `apel/db/records/job.py` is due to the fact the `_check_factor` method is being passed `None` if ServiceLevel is missing (rather than the string `'None'`). The output of `_check_factor` is not changed.

The test included in this PR stop short of actually trying to load the messages. As such this should be merged in after #135 , as that PR provides a test that will confirm this doesn't break the loader.