### PR TITLE
Fixes to XML parsers

### DIFF
--- a/apel/db/loader/xml_parser.py
+++ b/apel/db/loader/xml_parser.py
@@ -68,7 +68,7 @@ class XMLParser(object):
         retList = []
         for node in nodes:
             if (node.hasAttributeNS(namespace, name) and
-                    self.getAttr(node, name, self.NAMESPACE) == value):
+                    self.getAttr(node, name, namespace) == value):
                 retList.append(node)
         return retList
     

--- a/test/test_aur_parser.py
+++ b/test/test_aur_parser.py
@@ -1,116 +1,110 @@
-from unittest import TestCase
-import datetime
-from decimal import Decimal
+from datetime import datetime
+import unittest
+
 from apel.db.loader import AurParser
+from test_car_parser import datetimes_equal
 
-class AurParserTest(TestCase):
-    '''
-    Test case for AUR Parser
-    '''
 
-    def setUp(self):
-        pass
-        #self.parser = CarParser(self.example_data)
-    
+class AurParserTest(unittest.TestCase):
+    """Test case for AUR Parser"""
 
-# This currently fails because the AUR parser isn't working.    
+    def test_aur_parser(self):
+        # Careful!  I added a Z to the end of the dates here but they weren't there in the CAR spec...
+        example1 = '''<?xml version="1.0" encoding="UTF-8"?>
+<aur:SummaryRecord xmlns:aur="http://eu-emi.eu/namespaces/2012/11/aggregatedcomputerecord" xmlns:urf="http://eu-emi.eu/namespaces/2012/11/computerecord" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://eu-emi.eu/namespaces/2012/11/aggregatedcomputerecord ../org.glite.dgas_B_4_0_0/config-consumers/car_aggregated_v1.2.xsd ">
+  <aur:Site>aur:Site</aur:Site>
+  <aur:Month>1</aur:Month>
+  <aur:Year>2012</aur:Year>
+  <aur:UserIdentity/>
+  <aur:Infrastructure urf:type="grid"/>
+  <aur:EarliestEndTime>2012-01-01T12:00:00Z</aur:EarliestEndTime>
+  <aur:LatestEndTime>2012-01-31T12:00:00Z</aur:LatestEndTime>
+  <aur:WallDuration>P1D</aur:WallDuration>
+  <aur:CpuDuration>P1D</aur:CpuDuration>
+  <aur:ServiceLevel urf:type="token">0.0</aur:ServiceLevel>
+  <aur:NumberOfJobs>1</aur:NumberOfJobs>
+</aur:SummaryRecord>'''
 
-#    def test_aur_parser(self):
-#        
-#        # Careful!  I added a Z to the end of the dates here but they weren't there in the CAR spec...
-#        example1 = '''<?xml version="1.0" encoding="UTF-8"?>
-#<aur:SummaryRecord xmlns:aur="http://eu-emi.eu/namespaces/2012/11/aggregatedcomputerecord" xmlns:urf="http://eu-emi.eu/namespaces/2012/11/computerecord" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://eu-emi.eu/namespaces/2012/11/aggregatedcomputerecord ../org.glite.dgas_B_4_0_0/config-consumers/car_aggregated_v1.2.xsd ">
-#  <aur:Site>aur:Site</aur:Site>
-#  <aur:Month>1</aur:Month>
-#  <aur:Year>2012</aur:Year>
-#  <aur:UserIdentity/>
-#  <aur:Infrastructure urf:type="grid"/>
-#  <aur:EarliestEndTime>2012-01-01T12:00:00Z</aur:EarliestEndTime>
-#  <aur:LatestEndTime>2012-01-31T12:00:00Z</aur:LatestEndTime>
-#  <aur:WallDuration>P1D</aur:WallDuration>
-#  <aur:CpuDuration>P1D</aur:CpuDuration>
-#  <aur:ServiceLevel urf:type="token">0.0</aur:ServiceLevel>
-#  <aur:NumberOfJobs>1</aur:NumberOfJobs>
-#</aur:SummaryRecord>'''
-#    
-#        values1 = {"Site": "aur:Site", 
-#                        "Month": 1, 
-#                        "Year": 2012, 
-#                        "InfrastructureType": "grid",
-#                        "WallDuration":86400,
-#                        "CpuDuration": 86400,
-#   #                     "EarliestEndTime": datetime.datetime(2012, 1, 1, 12, 00, 00),
-#   #                     "LatestEndTime": datetime.datetime(2012, 1, 31, 12, 00, 00),
-#   #                     "ServiceLevel": Decimal(0.0),
-#                        "NumberOfJobs": 1
-#                        }
-#        
-#        example2 = '''<?xml version="1.0" encoding="UTF-8"?>
-#<aur:SummaryRecord xmlns:aur="http://eu-emi.eu/namespaces/2012/11/aggregatedcomputerecord" xmlns:urf="http://eu-emi.eu/namespaces/2012/11/computerecord" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://eu-emi.eu/namespaces/2012/11/aggregatedcomputerecord ../org.glite.dgas_B_4_0_0/config-consumers/car_aggregated_v1.2.xsd ">
-#  <aur:Site urf:type="gocdb">aur:Site</aur:Site>
-#  <aur:Month>1</aur:Month>
-#  <aur:Year>2012</aur:Year>
-#  <aur:UserIdentity>
-#    <urf:GlobalUserName urf:type="opensslCompat">urf:GlobalUserName</urf:GlobalUserName>
-#    <urf:Group>urf:Group</urf:Group>
-#    <urf:GroupAttribute urf:type="vo-group">vogroup</urf:GroupAttribute>
-#  </aur:UserIdentity>
-#  <aur:MachineName urf:description="">aur:MachineName</aur:MachineName>
-#  <aur:SubmitHost>aur:SubmitHost</aur:SubmitHost>
-#  <aur:Host primary="true" urf:description="">aur:Host</aur:Host>
-#  <aur:Queue urf:description="execution">aur:Queue</aur:Queue>
-#  <aur:Infrastructure urf:description="" urf:type="grid"/>
-#  <aur:Middleware urf:description="" urf:name="" urf:version="">aur:Middleware</aur:Middleware>
-#  <aur:EarliestEndTime>2012-01-01T12:00:00Z</aur:EarliestEndTime>
-#  <aur:LatestEndTime>2012-01-31T12:00:00Z</aur:LatestEndTime>
-#  <aur:WallDuration>P1D</aur:WallDuration>
-#  <aur:CpuDuration>P1D</aur:CpuDuration>
-#  <aur:ServiceLevel urf:description="" urf:type="token">0.0</aur:ServiceLevel>
-#  <aur:NumberOfJobs>1</aur:NumberOfJobs>
-#  <aur:Memory urf:description="" urf:metric="total" urf:phaseUnit="P1D" urf:storageUnit="b" urf:type="token">1</aur:Memory>
-#  <aur:Swap urf:description="" urf:metric="total" urf:phaseUnit="P1D" urf:storageUnit="b" urf:type="token">1</aur:Swap>
-#  <aur:NodeCount urf:description="" urf:metric="total">1</aur:NodeCount>
-#  <aur:Processors urf:consumptionRate="0.0" urf:description="" urf:metric="token">1</aur:Processors>
-#</aur:SummaryRecord>'''
-#
-#        values2 = {"Site": "aur:Site", 
-#                        "Month": 1, 
-#                        "Year": 2012, 
-#                        "SubmitHost": "aur:SubmitHost",
-#                        "VO": "urf:Group",
-#                        "VOGroup": "vogroup",
-#                        "InfrastructureType": "grid",
-#                        "WallDuration":86400,
-#                        "CpuDuration": 86400,
-# #                       "EarliestEndTime": datetime.datetime(2012, 1, 1, 12, 00, 00),
-# #                       "LatestEndTime": datetime.datetime(2012, 1, 31, 12, 00, 00),
-# #                       "ServiceLevel": Decimal(0.0),
-#                        "NumberOfJobs": 1,
-#                        "NodeCount": 1,
-#                        "Processors": 1
-#                        }
-#        
-#        
-#        # test CarRecord fields
-#        cases = {}
-#        cases[example1] = values1
-#        cases[example2] = values2
-#        
-#        for aur in cases.keys():
-#            
-#            parser  = AurParser(aur)
-#            record = parser.get_records()[0]
-#            cont = record._record_content
-#            
-#            # Mandatory fields - need checking.
-#            self.assertTrue(cont.has_key("Site"))
-#            self.assertTrue(cont.has_key("Month"))
-#            self.assertTrue(cont.has_key("Year"))
-#            self.assertTrue(cont.has_key("WallDuration"))
-#            self.assertTrue(cont.has_key("CpuDuration"))
-#            self.assertTrue(cont.has_key("NumberOfJobs"))
-#        
-#        
-#            for key in cases[aur].keys():
-#                print key
-#                self.assertEqual(cont[key], cases[aur][key], "%s != %s for key %s" % (cont[key], cases[aur][key], key))
+        values1 = {"Site": "aur:Site",
+                   "Month": 1,
+                   "Year": 2012,
+                   #"Infrastructure": "grid",
+                   "WallDuration": 86400,
+                   "CpuDuration": 86400,
+                   "EarliestEndTime": datetime(2012, 1, 1, 12, 00, 00),
+                   "LatestEndTime": datetime(2012, 1, 31, 12, 00, 00),
+                   # "ServiceLevel": Decimal(0.0),
+                   "NumberOfJobs": 1
+                   }
+
+        example2 = '''<?xml version="1.0" encoding="UTF-8"?>
+<aur:SummaryRecord xmlns:aur="http://eu-emi.eu/namespaces/2012/11/aggregatedcomputerecord" xmlns:urf="http://eu-emi.eu/namespaces/2012/11/computerecord" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://eu-emi.eu/namespaces/2012/11/aggregatedcomputerecord ../org.glite.dgas_B_4_0_0/config-consumers/car_aggregated_v1.2.xsd ">
+  <aur:Site urf:type="gocdb">aur:Site</aur:Site>
+  <aur:Month>1</aur:Month>
+  <aur:Year>2012</aur:Year>
+  <aur:UserIdentity>
+    <urf:GlobalUserName urf:type="opensslCompat">urf:GlobalUserName</urf:GlobalUserName>
+    <urf:Group>urf:Group</urf:Group>
+    <urf:GroupAttribute urf:type="vo-group">vogroup</urf:GroupAttribute>
+  </aur:UserIdentity>
+  <aur:MachineName urf:description="">aur:MachineName</aur:MachineName>
+  <aur:SubmitHost>aur:SubmitHost</aur:SubmitHost>
+  <aur:Host primary="true" urf:description="">aur:Host</aur:Host>
+  <aur:Queue urf:description="execution">aur:Queue</aur:Queue>
+  <aur:Infrastructure urf:description="" urf:type="grid"/>
+  <aur:Middleware urf:description="" urf:name="" urf:version="">aur:Middleware</aur:Middleware>
+  <aur:EarliestEndTime>2012-01-01T12:00:00Z</aur:EarliestEndTime>
+  <aur:LatestEndTime>2012-01-31T12:00:00Z</aur:LatestEndTime>
+  <aur:WallDuration>P1D</aur:WallDuration>
+  <aur:CpuDuration>P1D</aur:CpuDuration>
+  <aur:ServiceLevel urf:description="" urf:type="token">0.0</aur:ServiceLevel>
+  <aur:NumberOfJobs>1</aur:NumberOfJobs>
+  <aur:Memory urf:description="" urf:metric="total" urf:phaseUnit="P1D" urf:storageUnit="b" urf:type="token">1</aur:Memory>
+  <aur:Swap urf:description="" urf:metric="total" urf:phaseUnit="P1D" urf:storageUnit="b" urf:type="token">1</aur:Swap>
+  <aur:NodeCount urf:description="" urf:metric="total">1</aur:NodeCount>
+  <aur:Processors urf:consumptionRate="0.0" urf:description="" urf:metric="token">1</aur:Processors>
+</aur:SummaryRecord>'''
+
+        values2 = {"Site": "aur:Site",
+                   "Month": 1,
+                   "Year": 2012,
+                   "SubmitHost": "aur:SubmitHost",
+                   "VO": "urf:Group",
+                   #"VOGroup": "vogroup",
+                   #"Infrastructure": "grid",
+                   "WallDuration": 86400,
+                   "CpuDuration": 86400,
+                   "EarliestEndTime": datetime(2012, 1, 1, 12, 00, 00),
+                   "LatestEndTime": datetime(2012, 1, 31, 12, 00, 00),
+                   # "ServiceLevel": Decimal(0.0),
+                   "NumberOfJobs": 1,
+                   "NodeCount": 1,
+                   "Processors": 1
+                   }
+
+        # test CarRecord fields
+        cases = {}
+        cases[example1] = values1
+        cases[example2] = values2
+
+        for aur in cases:
+            parser = AurParser(aur)
+            record = parser.get_records()[0]
+            cont = record._record_content
+
+            # Mandatory fields - need checking.
+            for field in ('Site', 'Month', 'Year',
+                          'WallDuration', 'CpuDuration', 'NumberOfJobs'):
+                # 'ServiceLevel',
+                self.assertTrue(field in cont, "Field '%s' not found" % field)
+
+            for key in cases[aur]:
+                if isinstance(cont[key], datetime):
+                    if not datetimes_equal(cont[key], cases[aur][key]):
+                        self.fail("Datetimes don't match for key %s: %s, %s" % (key, cont[key], cases[aur][key]))
+                else:
+                    self.assertEqual(cont[key], cases[aur][key], "%s != %s for key %s" % (cont[key], cases[aur][key], key))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_aur_parser.py
+++ b/test/test_aur_parser.py
@@ -28,12 +28,12 @@ class AurParserTest(unittest.TestCase):
         values1 = {"Site": "aur:Site",
                    "Month": 1,
                    "Year": 2012,
-                   #"Infrastructure": "grid",
+                   "Infrastructure": "grid",
                    "WallDuration": 86400,
                    "CpuDuration": 86400,
                    "EarliestEndTime": datetime(2012, 1, 1, 12, 00, 00),
                    "LatestEndTime": datetime(2012, 1, 31, 12, 00, 00),
-                   # "ServiceLevel": Decimal(0.0),
+                   #"ServiceLevel": Decimal('0.0'),
                    "NumberOfJobs": 1
                    }
 
@@ -44,7 +44,7 @@ class AurParserTest(unittest.TestCase):
   <aur:Year>2012</aur:Year>
   <aur:UserIdentity>
     <urf:GlobalUserName urf:type="opensslCompat">urf:GlobalUserName</urf:GlobalUserName>
-    <urf:Group>urf:Group</urf:Group>
+    <urf:Group>TestGroup</urf:Group>
     <urf:GroupAttribute urf:type="vo-group">vogroup</urf:GroupAttribute>
   </aur:UserIdentity>
   <aur:MachineName urf:description="">aur:MachineName</aur:MachineName>
@@ -69,9 +69,9 @@ class AurParserTest(unittest.TestCase):
                    "Month": 1,
                    "Year": 2012,
                    "SubmitHost": "aur:SubmitHost",
-                   "VO": "urf:Group",
-                   #"VOGroup": "vogroup",
-                   #"Infrastructure": "grid",
+                   "VO": "TestGroup",
+                   "VOGroup": "vogroup",
+                   "Infrastructure": "grid",
                    "WallDuration": 86400,
                    "CpuDuration": 86400,
                    "EarliestEndTime": datetime(2012, 1, 1, 12, 00, 00),
@@ -95,7 +95,7 @@ class AurParserTest(unittest.TestCase):
             # Mandatory fields - need checking.
             for field in ('Site', 'Month', 'Year',
                           'WallDuration', 'CpuDuration', 'NumberOfJobs'):
-                # 'ServiceLevel',
+                # Also need: 'NormalisedWallDuration', 'NormalisedCpuDuration'
                 self.assertTrue(field in cont, "Field '%s' not found" % field)
 
             for key in cases[aur]:
@@ -104,6 +104,9 @@ class AurParserTest(unittest.TestCase):
                         self.fail("Datetimes don't match for key %s: %s, %s" % (key, cont[key], cases[aur][key]))
                 else:
                     self.assertEqual(cont[key], cases[aur][key], "%s != %s for key %s" % (cont[key], cases[aur][key], key))
+
+            # This should pass
+            # record.get_db_tuple()
 
 
 if __name__ == '__main__':

--- a/test/test_aur_parser.py
+++ b/test/test_aur_parser.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import unittest
 
 from apel.db.loader import AurParser
+from apel.db.loader.xml_parser import XMLParserException
 from test_car_parser import datetimes_equal
 
 
@@ -107,6 +108,13 @@ class AurParserTest(unittest.TestCase):
 
             # This should pass
             # record.get_db_tuple()
+
+    def test_empty_xml(self):
+        """
+        Check that correct exception is raised for an XML file with no records.
+        """
+        parser = AurParser("<something></something>")
+        self.assertRaises(XMLParserException, parser.get_records)
 
 
 if __name__ == '__main__':

--- a/test/test_car_parser.py
+++ b/test/test_car_parser.py
@@ -1,27 +1,24 @@
-from unittest import TestCase
 import datetime
+import unittest
+
 from apel.db.loader import CarParser
 
 
 def datetimes_equal(dt1, dt2):
-    '''
-    Compare if datetimes are equal to the nearest second.
-    '''
+    """Compare if datetimes are equal to the nearest second."""
     diff = dt1 - dt2
-    return abs(diff) < datetime.timedelta(seconds = 1)
+    return abs(diff) < datetime.timedelta(seconds=1)
 
-class CarParserTest(TestCase):
-    '''
-    Test case for Car Parser
-    '''
-    
+
+class CarParserTest(unittest.TestCase):
+    """Test case for Car Parser"""
+
     def setUp(self):
         pass
         #self.parser = CarParser(self.example_data)
-    
+
     def test_car_parser(self):
-        
-        # Careful!  I added a Z to the end of the dates here but they weren't there in the CAR spec...
+        # Careful! I added a Z to the end of the dates here but they weren't there in the CAR spec...
         car1 = '''<?xml version="1.0" encoding="UTF-8"?>
 <urf:UsageRecord xmlns:urf="http://eu-emi.eu/namespaces/2012/11/computerecord" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://eu-emi.eu/namespaces/2012/11/computerecord ../../../org.glite.dgas_B_4_0_0/config-consumers/car_v1.2.xsd ">
   <urf:RecordIdentity urf:createTime="2001-12-31T12:00:00Z" urf:recordId="token"/>
@@ -43,17 +40,17 @@ class CarParserTest(TestCase):
   <urf:Site>urf:Site</urf:Site>
 </urf:UsageRecord>
 '''
-        
-        values1 = {'Site': 'urf:Site', 
-                        'MachineName':'MachineName',
-                        'LocalJobId':'urf:LocalJobId', 
-                        'LocalUserId': 'urf:LocalUserId', 
-                        'WallDuration': 86400,
-                        'CpuDuration': 86400,
-                        'StartTime': datetime.datetime(2001, 12, 31, 12, 00, 00),
-                        'EndTime': datetime.datetime(2001, 12, 31, 12, 00, 00),
-                        }
-        
+
+        values1 = {'Site': 'urf:Site',
+                   'MachineName': 'MachineName',
+                   'LocalJobId': 'urf:LocalJobId',
+                   'LocalUserId': 'urf:LocalUserId',
+                   'WallDuration': 86400,
+                   'CpuDuration': 86400,
+                   'StartTime': datetime.datetime(2001, 12, 31, 12, 00, 00),
+                   'EndTime': datetime.datetime(2001, 12, 31, 12, 00, 00),
+                   }
+
         car2 = '''<?xml version="1.0"?>
 <UsageRecords xmlns="http://eu-emi.eu/namespaces/2012/11/computerecord">
   <UsageRecord xmlns:urf="http://eu-emi.eu/namespaces/2012/11/computerecord" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -87,23 +84,22 @@ class CarParserTest(TestCase):
     <Host urf:primary="true">pgs03</Host>
     <Host>pgs03.grid.upjs.sk</Host></UsageRecord>
 </UsageRecords>'''
-            
-        values2 = {"Site": "PGS03-GRID-UPJS-SK", 
-                        "MachineName":"pgs03.grid.upjs.sk", 
-                        "LocalJobId":"jobid10", 
-                        "LocalUserId": "gridtest", 
-                        "WallDuration":4,
-                        "CpuDuration": 3,
-                        "ServiceLevelType": "Si2K",
-                        "ServiceLevel": 1,
-                        "NodeCount": 2,
-                        "StartTime": datetime.datetime(2013, 2, 9, 15, 9, 16),
-                        "EndTime": datetime.datetime(2013, 2, 9, 15, 11, 41),
-                        "SubmitHost": "gsiftp://pgs03.grid.upjs.sk:2811/jobs",
-                        "Queue": "gridlong"
-                        }
-        
-        
+
+        values2 = {"Site": "PGS03-GRID-UPJS-SK",
+                   "MachineName": "pgs03.grid.upjs.sk",
+                   "LocalJobId": "jobid10",
+                   "LocalUserId": "gridtest",
+                   "WallDuration": 4,
+                   "CpuDuration": 3,
+                   "ServiceLevelType": "Si2K",
+                   "ServiceLevel": 1,
+                   "NodeCount": 2,
+                   "StartTime": datetime.datetime(2013, 2, 9, 15, 9, 16),
+                   "EndTime": datetime.datetime(2013, 2, 9, 15, 11, 41),
+                   "SubmitHost": "gsiftp://pgs03.grid.upjs.sk:2811/jobs",
+                   "Queue": "gridlong"
+                   }
+
         car3 = '''<com:UsageRecord xmlns:com="http://eu-emi.eu/namespaces/2012/11/computerecord">
         <com:RecordIdentity com:recordId="62991a08-909b-4516-aa30-3732ab3d8998" com:createTime="2013-02-22T15:58:44.567+01:00"/>
         <com:JobIdentity>
@@ -142,50 +138,51 @@ class CarParserTest(TestCase):
         <com:Site>zam052v15.zam.kfa-juelich.de</com:Site>
         <com:Host com:primary="false" com:description="CPUS=2;SLOTS=1,0">zam052v15</com:Host>
         </com:UsageRecord>'''
-        
-        values3 = {
-                        "LocalJobId":"7005", 
-                        "GlobalUserName": "CN=Bjoern Hagemeier,OU=Forschungszentrum Juelich GmbH,O=GridGermany,C=DE",
-                        "LocalUserId": "bjoernh", 
-                        "InfrastructureType": "grid",
-                        'WallDuration': 0,
-                        'CpuDuration': 0,
-                        'ServiceLevelType': 'HEPSPEC',
-                        'ServiceLevel': 1,
-                        'NodeCount': 1,
-                        'Processors': 2,
-                        'StartTime': datetime.datetime(2013, 2, 22, 14, 58, 45),
-                        'EndTime': datetime.datetime(2013, 2, 22, 14, 58, 45),
-                        'MachineName':'zam052v15.zam.kfa-juelich.de', 
-                        'SubmitHost': 'zam052v02',
-                        'Queue': 'batch',
-                        'Site': 'zam052v15.zam.kfa-juelich.de' 
-                        }
+
+        values3 = {"LocalJobId": "7005",
+                   "GlobalUserName": "CN=Bjoern Hagemeier,OU=Forschungszentrum Juelich GmbH,O=GridGermany,C=DE",
+                   "LocalUserId": "bjoernh",
+                   "InfrastructureType": "grid",
+                   'WallDuration': 0,
+                   'CpuDuration': 0,
+                   'ServiceLevelType': 'HEPSPEC',
+                   'ServiceLevel': 1,
+                   'NodeCount': 1,
+                   'Processors': 2,
+                   'StartTime': datetime.datetime(2013, 2, 22, 14, 58, 45),
+                   'EndTime': datetime.datetime(2013, 2, 22, 14, 58, 45),
+                   'MachineName': 'zam052v15.zam.kfa-juelich.de',
+                   'SubmitHost': 'zam052v02',
+                   'Queue': 'batch',
+                   'Site': 'zam052v15.zam.kfa-juelich.de'
+                   }
 
         cases = {}
         cases[car1] = values1
         cases[car2] = values2
         cases[car3] = values3
-        
+
         for car in cases:
-            
-            parser  = CarParser(car)
+
+            parser = CarParser(car)
             record = parser.get_records()[0]
             cont = record._record_content
-            
+
             #  Mandatory fields - need checking.
-            self.assertTrue(cont.has_key('Site'))
-            self.assertTrue(cont.has_key('Queue'))
-            self.assertTrue(cont.has_key('LocalJobId'))
-            self.assertTrue(cont.has_key('WallDuration'))
-            self.assertTrue(cont.has_key('CpuDuration'))
-            self.assertTrue(cont.has_key('StartTime'))
-            self.assertTrue(cont.has_key('EndTime'))
-        
-        
+            self.assertTrue('Site' in cont)
+            self.assertTrue('Queue' in cont)
+            self.assertTrue('LocalJobId' in cont)
+            self.assertTrue('WallDuration' in cont)
+            self.assertTrue('CpuDuration' in cont)
+            self.assertTrue('StartTime' in cont)
+            self.assertTrue('EndTime' in cont)
+
             for key in cases[car].keys():
                 if isinstance(cont[key], datetime.datetime):
                     if not datetimes_equal(cont[key], cases[car][key]):
                         self.fail("Datetimes don't match for key %s: %s, %s" % (key, cont[key], cases[car][key]))
                 else:
                     self.assertEqual(cont[key], cases[car][key], '%s != %s for key %s' % (cont[key], cases[car][key], key))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Main fix is to `xml_parser.py`. The `getTagByAttr` method in that should have been using the namespace it's given as an argument throughout (so that you can choose the namespace when you call it) but it was using `self.NAMESPACE` for one of the calls it makes and thus overriding your choice. This is the most significant change as it affects all the other XML parsers (StAR, CAR, AUR), but doesn't seem to have been a problem for the StAR parser as it uses a uniform namespace.
- Added a regression test for this.
- Tidied up the CAR parser.
- Fixed the AUR parser somewhat. It still doesn't work out normalised durations, but can now get Infrastructure, VOGroup, and VORole. (It's never really worked, to be fair! It's even disabled in `record_factory.py`.)
- Fixed the test for the AUR parser.