### PR TITLE
Minor fixes and improved coverage

### DIFF
--- a/apel/db/apeldb.py
+++ b/apel/db/apeldb.py
@@ -130,8 +130,8 @@ class Query(object):
                     wh += '"' + item + '",'
                     
                 wh = wh[:-1] + ')'
-                
-                elems.append(column + ' in ' + wh)
+
+                elems.append(column + ' IN ' + wh)
             elif elem.endswith("_notin"):
                 column = elem[:-6]
                 wh = '('
@@ -139,14 +139,14 @@ class Query(object):
                     wh += '"' + item + '",'
                     
                 wh = wh[:-1] + ')'
-                
-                elems.append(column + ' not in ' + wh)
+
+                elems.append(column + ' NOT IN ' + wh)
             elif '_' in elem:
                 column, relation = elem.split('_')
                 if relation not in RELATIONS:
                     raise ApelDbException('Unknown relation: %s' % relation)
                 elems.append( column + RELATIONS[relation] + "'" + str(self.__dict__[elem]) + "'" )
             else:
-                elems.append( elem + '=' + "'" + str(self.__dict__[elem]) + "'")
-        
+                elems.append(elem + ' = ' + "'" + str(self.__dict__[elem]) + "'")
+
         return elems

--- a/apel/parsers/__init__.py
+++ b/apel/parsers/__init__.py
@@ -22,6 +22,7 @@ LOGGER_ID = 'parser'
 
 from parser import Parser
 from blah import BlahParser
+from htcondor import HTCondorParser
 from lsf import LSFParser
 from pbs import PBSParser
 from sge import SGEParser

--- a/test/test_apeldb.py
+++ b/test/test_apeldb.py
@@ -1,0 +1,58 @@
+import unittest
+
+from apel.db.apeldb import ApelDb, ApelDbException, Query
+
+
+class TestApelDb(unittest.TestCase):
+    def test_unknown_db(self):
+        """Check that trying to use an unknown db raises an exception."""
+        self.assertRaises(ApelDbException, ApelDb, 'wibble',
+                          'testhost', 1234, 'groot', '', 'badtest')
+
+
+class TestQuery(unittest.TestCase):
+    """These test cases check the workings of the Query.get_where method."""
+
+    def setUp(self):
+        self.query = Query()
+
+    def test_bad_relation(self):
+        self.query.TestField_bad = 3
+        self.assertRaises(ApelDbException, self.query.get_where)
+
+    def test_empty_where(self):
+        self.assertEqual(self.query.get_where(), "")
+
+    def test_get_lt(self):
+        self.query.TestField_lt = 0
+        self.assertEqual(self.query.get_where(), " WHERE TestField < '0'")
+
+    def test_get_gt(self):
+        self.query.TestField_gt = 13
+        self.assertEqual(self.query.get_where(), " WHERE TestField > '13'")
+
+    def test_get_le(self):
+        self.query.TestField_le = 10
+        self.assertEqual(self.query.get_where(), " WHERE TestField <= '10'")
+
+    def test_get_ge(self):
+        self.query.TestField_ge = 12
+        self.assertEqual(self.query.get_where(), " WHERE TestField >= '12'")
+
+    def test_get_e(self):
+        self.query.TestField = 7
+        self.assertEqual(self.query.get_where(), " WHERE TestField = '7'")
+
+    def test_in(self):
+        self.query.TestField_in = ('one', 'two')
+        self.assertEqual(self.query.get_where(),
+                         ' WHERE TestField IN ("one","two")')
+
+    def test_notin(self):
+        self.query.TestField_notin = ('one', 'two')
+        self.assertEqual(self.query.get_where(),
+                         ' WHERE TestField NOT IN ("one","two")')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_apeldb.py
+++ b/test/test_apeldb.py
@@ -1,9 +1,12 @@
+"""Test cases for classes in apel.db.apeldb."""
+
 import unittest
 
 from apel.db.apeldb import ApelDb, ApelDbException, Query
 
 
 class TestApelDb(unittest.TestCase):
+    """Test case(s) for base ApelDb class functionality."""
     def test_unknown_db(self):
         """Check that trying to use an unknown db raises an exception."""
         self.assertRaises(ApelDbException, ApelDb, 'wibble',
@@ -14,41 +17,51 @@ class TestQuery(unittest.TestCase):
     """These test cases check the workings of the Query.get_where method."""
 
     def setUp(self):
+        """Create an instance of apeldb.Query for use in test cases."""
         self.query = Query()
 
     def test_bad_relation(self):
+        """Check that nonsense relationships lead to a raised exception."""
         self.query.TestField_bad = 3
         self.assertRaises(ApelDbException, self.query.get_where)
 
     def test_empty_where(self):
+        """Check that a query with no relationships gives no WHERE clause."""
         self.assertEqual(self.query.get_where(), "")
 
     def test_get_lt(self):
+        """Check that a less than gives the correct WHERE."""
         self.query.TestField_lt = 0
         self.assertEqual(self.query.get_where(), " WHERE TestField < '0'")
 
     def test_get_gt(self):
+        """Check that a greater than gives the correct WHERE."""
         self.query.TestField_gt = 13
         self.assertEqual(self.query.get_where(), " WHERE TestField > '13'")
 
     def test_get_le(self):
+        """Check that a less than or equal gives the correct WHERE."""
         self.query.TestField_le = 10
         self.assertEqual(self.query.get_where(), " WHERE TestField <= '10'")
 
     def test_get_ge(self):
+        """Check that a greater than or equal gives the correct WHERE."""
         self.query.TestField_ge = 12
         self.assertEqual(self.query.get_where(), " WHERE TestField >= '12'")
 
     def test_get_e(self):
+        """Check that an undecorated field gives an equal WHERE."""
         self.query.TestField = 7
         self.assertEqual(self.query.get_where(), " WHERE TestField = '7'")
 
     def test_in(self):
+        """Check that an 'in' relationship gives the correct WHERE."""
         self.query.TestField_in = ('one', 'two')
         self.assertEqual(self.query.get_where(),
                          ' WHERE TestField IN ("one","two")')
 
     def test_notin(self):
+        """Check that a 'not in' relationship gives the correct WHERE."""
         self.query.TestField_notin = ('one', 'two')
         self.assertEqual(self.query.get_where(),
                          ' WHERE TestField NOT IN ("one","two")')

--- a/test/test_car_parser.py
+++ b/test/test_car_parser.py
@@ -187,10 +187,16 @@ class CarParserTest(unittest.TestCase):
 
     def test_empty_xml(self):
         """
-        Check that correct exception is raised for an XML file with no records.
+        Check that exception is raised for XML not in computerecord namepsace.
         """
         parser = CarParser("<something></something>")
         self.assertRaises(XMLParserException, parser.get_records)
+
+    #def test_empty_record(self):
+    #    # Not sure what should be returned with an empty record like this.
+    #    parser = CarParser('<urf:UsageRecord xmlns:urf="http://eu-emi.eu/namesp'
+    #                       'aces/2012/11/computerecord"></urf:UsageRecord>')
+    #    print parser.get_records()[0]._record_content
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_car_parser.py
+++ b/test/test_car_parser.py
@@ -2,6 +2,7 @@ import datetime
 import unittest
 
 from apel.db.loader import CarParser
+from apel.db.loader.xml_parser import XMLParserException
 
 
 def datetimes_equal(dt1, dt2):
@@ -183,6 +184,13 @@ class CarParserTest(unittest.TestCase):
                         self.fail("Datetimes don't match for key %s: %s, %s" % (key, cont[key], cases[car][key]))
                 else:
                     self.assertEqual(cont[key], cases[car][key], '%s != %s for key %s' % (cont[key], cases[car][key], key))
+
+    def test_empty_xml(self):
+        """
+        Check that correct exception is raised for an XML file with no records.
+        """
+        parser = CarParser("<something></something>")
+        self.assertRaises(XMLParserException, parser.get_records)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_job_record.py
+++ b/test/test_job_record.py
@@ -63,4 +63,41 @@ class TestJobRecord(unittest.TestCase):
             record._check_fields()
         except:
             self.fail('Minimal record was not accepted!')
-        
+
+    def test_get_ur(self):
+        """Check that get_ur outputs correct XML."""
+        jr = JobRecord()
+        jr.load_from_msg('''
+Site: UK-UTOPIA
+LocalJobId: some-id
+WallDuration: 6704
+CpuDuration: 19872
+StartTime: 1504779367
+EndTime: 1504786071''')
+
+        xml = (
+            '<urf:UsageRecord><urf:RecordIdentity urf:createTime="xxxx-xx-xxTxx'
+            ':xx:xx" urf:recordId="None some-id 2017-09-07 12:07:51"/><urf:JobI'
+            'dentity><urf:LocalJobId>some-id</urf:LocalJobId></urf:JobIdentity>'
+            '<urf:UserIdentity><urf:GlobalUserName urf:type="opensslCompat">Non'
+            'e</urf:GlobalUserName><urf:Group>None</urf:Group><urf:GroupAttribu'
+            'te urf:type="FQAN">None</urf:GroupAttribute><urf:GroupAttribute ur'
+            'f:type="vo-group">None</urf:GroupAttribute><urf:GroupAttribute urf'
+            ':type="vo-role">None</urf:GroupAttribute><urf:LocalUserId>None</ur'
+            'f:LocalUserId></urf:UserIdentity><urf:Status>completed</urf:Status'
+            '><urf:Infrastructure urf:type="None"/><urf:WallDuration>PT6704S</u'
+            'rf:WallDuration><urf:CpuDuration urf:usageType="all">PT19872S</urf'
+            ':CpuDuration><urf:ServiceLevel urf:type="custom">1</urf:ServiceLev'
+            'el><urf:EndTime>2017-09-07T12:07:51Z</urf:EndTime><urf:StartTime>2'
+            '017-09-07T10:16:07Z</urf:StartTime><urf:MachineName>None</urf:Mach'
+            'ineName><urf:SubmitHost>None</urf:SubmitHost><urf:Queue>None</urf:'
+            'Queue><urf:Site>UK-UTOPIA</urf:Site></urf:UsageRecord>'
+        )
+        xml_out = jr.get_ur()
+
+        # We have to avoid comparing the createTime as that changes.
+        self.assertEqual(xml_out[:53], xml[:53])
+        self.assertEqual(xml_out[72:], xml[72:])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -1,3 +1,5 @@
+"""Test cases for logging function in apel.common.__init__."""
+
 from cStringIO import StringIO
 import logging
 import os
@@ -9,6 +11,7 @@ from apel.common import set_up_logging
 
 
 class LoggingTest(unittest.TestCase):
+    """Test cases for set_up_logging function."""
     def setUp(self):
         # Capture stdout in a StringIO object for inspection.
         self._stdout = sys.stdout

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -1,0 +1,54 @@
+from cStringIO import StringIO
+import logging
+import os
+import sys
+import tempfile
+import unittest
+
+from apel.common import set_up_logging
+
+
+class LoggingTest(unittest.TestCase):
+    def setUp(self):
+        # Capture stdout in a StringIO object for inspection.
+        self._stdout = sys.stdout
+        sys.stdout = StringIO()
+        # Create a temporary file to write log to
+        handle, self.path = tempfile.mkstemp()
+        os.close(handle)
+
+    def tearDown(self):
+        # Restore stdout to normal.
+        sys.stdout.close()
+        sys.stdout = self._stdout
+        # Delete temporary file
+        os.remove(self.path)
+
+    def test_stdout_logging(self):
+        """
+        Check that logging to stdout and file works, ignoring timestamp.
+
+        These are tested together as otherwise the logger setup conflicts.
+        """
+        set_up_logging(self.path, 'INFO', True)
+        log = logging.getLogger('test_logging')
+        log.info('out')
+
+        # Retrieve output from StringIO object.
+        output = sys.stdout.getvalue()
+        # Shutdown logging to release log file for later deletion.
+        logging.shutdown()
+
+        # Only check bit after timestamp as that doesn't change.
+        self.assertEqual(output[23:], " - test_logging - INFO - out\n")
+        f = open(self.path)
+        self.assertEqual(f.readline()[23:], " - test_logging - INFO - out\n")
+        f.close()
+
+    def test_boring_logging(self):
+        """Check that logging without handlers at least runs without errors."""
+        set_up_logging(None, 'INFO', False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_lsf.py
+++ b/test/test_lsf.py
@@ -117,8 +117,49 @@ class ParserLSFTest(unittest.TestCase):
                 '"/afs/cern.ch/user/r/raortega/log/berr-step3c-362.txt""1089290023.699195" 0 1 "tbed0079" 64 3.3 "" '
                 '"/afs/cern.ch/user/r/raortega/prog/step3c/startEachset.pl362 7 8" 277.210000 17.280000 0 0 -1 0 0 927804'
                 ' 87722 0 0 0 -1 0 0 0 0 0 -1 "" "default" 0 1 "" "" 0 310424 339112 "" "" ""')
-        
+
         self.assertRaises(IndexError, self.parser.parse, line)
+
+    def test_wall_value_error(self):
+        """Check that stop before start raises a ValueError."""
+        line = ('"JOB_FINISH" "5.1" 1089407406 699195 283 33554482 1 1089290023'
+                ' 0 0 1089409862 "raortega" "8nm" "" "" "" "lxplus015" "prog/st'
+                'ep3c" "" "/step3c-362.txt" "/berr-step3c-362.txt" "1089290023.'
+                '699195" 0 1 "tbed0079" 64 3.3 "" "/artEachset.j 362 7 8" 277.2'
+                '10000 17.280000 0 0 -1 0 0 927804 87722 0 0 0 -1 0 0 0 0 0 -1 '
+                '"" "default" 0 1 "" "" 0 310424 339112 "" "" ""')
+        self.assertRaises(ValueError, self.parser.parse, line)
+
+    def test_unfinished(self):
+        """Check that a valid line without JOB_FINISH returns None."""
+        line = ('"JOB_RESIZE" "5.1" 1089407406 699195 283 33554482 1 1089290023'
+                ' 0 0 1089406862 "raortega" "8nm" "" "" "" "lxplus015" "prog/st'
+                'ep3c" "" "/step3c-362.txt" "/berr-step3c-362.txt" "1089290023.'
+                '699195" 0 1 "tbed0079" 64 3.3 "" "/artEachset.j 362 7 8" 277.2'
+                '10000 17.280000 0 0 -1 0 0 927804 87722 0 0 0 -1 0 0 0 0 0 -1 '
+                '"" "default" 0 1 "" "" 0 310424 339112 "" "" ""')
+
+        self.assertEqual(self.parser.parse(line), None)
+
+    def test_non_mpi(self):
+        """Test that node and cpu count are set to zero if MPI isn't used."""
+        parser = LSFParser('testSite', 'testHost', False)
+
+        line = ('"JOB_FINISH" "5.1" 1089407406 699195 283 33554482 1 1089290023'
+                ' 0 0 1089406862 "raortega" "8nm" "" "" "" "lxplus015" "prog/st'
+                'ep3c" "" "/af/step3c-362.txt" "/af/epc-362.txt" "1089290023.69'
+                '9195" 0 1 "tbed0079" 64 3.3 "" "/af/hset.pl 362 7 8" 277.2100 '
+                '17.280000 0 0 -1 0 0 927804 87722 0 0 0 -1 0 0 0 0 0 -1 "" "de'
+                'fault" 0 1 "" "" 0 310424 339112 "" "" ""')
+
+        record = parser.parse(line)
+        cont = record._record_content
+
+        self.assertEquals(cont['NodeCount'], 0,
+                          "Node count not zero for non-mpi parser")
+        self.assertEquals(cont['Processors'], 0,
+                          "Processors not zero for non-mpi parser")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_norm_sum_record.py
+++ b/test/test_norm_sum_record.py
@@ -95,6 +95,25 @@ class TestNormalisedSummaryRecord(unittest.TestCase):
                 self.fail("Summary record values don't match: %s != %s" %
                           (item1, item2))
 
+    def test_get_ur(self):
+        """Check that get_ur outputs correct XML."""
+        nsr = NormalisedSummaryRecord()
+        nsr.load_from_msg(self._records[0])
+        xml = ('<aur:SummaryRecord><aur:Site>RAL-LCG2</aur:Site><aur:Month>3</a'
+               'ur:Month><aur:Year>2010</aur:Year><aur:UserIdentity><urf:GroupA'
+               'ttribute urf:type="vo-group">/atlas</urf:GroupAttribute><urf:Gr'
+               'oupAttribute urf:type="vo-role">Role=production</urf:GroupAttri'
+               'bute></aur:UserIdentity><aur:SubmitHost>some.host.org</aur:Subm'
+               'itHost><aur:Infrastructure urf:type="grid"/><aur:EarliestEndTim'
+               'e>2010-03-01T01:00:00Z</aur:EarliestEndTime><aur:LatestEndTime>'
+               '2010-03-20T01:00:00Z</aur:LatestEndTime><aur:WallDuration>PT234'
+               '256S</aur:WallDuration><aur:CpuDuration>PT244435S</aur:CpuDurat'
+               'ion><aur:NormalisedWallDuration>PT234256S</aur:NormalisedWallDu'
+               'ration><aur:NormalisedCpuDuration>PT244435S</aur:NormalisedCpuD'
+               'uration><aur:NumberOfJobs>100</aur:NumberOfJobs></aur:SummaryRe'
+               'cord>')
+        self.assertEqual(nsr.get_ur(), xml)
+
     def _get_record_text(self):
         """Gets some sample valid records, as a tuple of strings.  The contents
         must match the values in _get_record_tuples."""

--- a/test/test_parsers.py
+++ b/test/test_parsers.py
@@ -1,0 +1,89 @@
+import unittest
+
+import apel.parsers
+
+
+class BaseParserTest(unittest.TestCase):
+    """Test cases for the base APEL parser class."""
+
+    def setUp(self):
+        self.parser = apel.parsers.Parser('testSite', 'testHost')
+
+    def test_constants(self):
+        """Check that the constants are set as expected."""
+        self.assertEqual(self.parser.UNPROCESSED, '0')
+        self.assertEqual(self.parser.PROCESSED, '1')
+
+    def test_base_parse(self):
+        """Check that parsing with the base parser fails with an error."""
+        self.assertRaises(NotImplementedError, self.parser.parse, 'line')
+
+    def test_base_recognize(self):
+        """Check that using recognize with the base parser gives False."""
+        self.assertFalse(self.parser.recognize('line'))
+
+
+class AllParsersRecognizeTest(unittest.TestCase):
+    """Test cases for the parser recognize method."""
+
+    def test_good(self):
+        """Check that each parser's recognize method works for a sample line."""
+        tests = {
+            'Blah': (
+                '"timestamp=2012-05-20 23:59:47" "userDN=/O=Gd/OU=Un/CN=Chp" "u'
+                'serFQAN=/atlas/Role=prod" "ceID=cream.grid.io" "jobID=CREAM123'
+                '" "lrmsID=9575064.lrms1" "localUser=11999"'),
+            'HTCondor': 'ce.rl#276.0#7189|ts11|287|107|11|1463|140|236|232|1|1',
+            'LSF': (
+                '"JOB_FINISH" "5.1" 1089407406 699195 283 33554482 1 1089290023'
+                ' 0 0 1089406862 "raortega" "8nm" "" "" "" "lxplus015" "prog/st'
+                'ep3c" "" "/step3c-362.txt" "/berr-step3c-362.txt" "1089290023.'
+                '699195" 0 1 "tbed0079" 64 3.3 "" "/artEachset.j 362 7 8" 277.2'
+                '10000 17.280000 0 0 -1 0 0 927804 87722 0 0 0 -1 0 0 0 0 0 -1 '
+                '"" "default" 0 1 "" "" 0 310424 339112 "" "" ""'),
+            'PBS': (
+                '04/30/2014 15:36:20;E;5000.bob;user=dbeer group=dbeer jobname='
+                'STDIN queue=batch ctime=1398892818 qtime=1398892818 etime=1398'
+                '892818 start=1398893580 owner=dbeer@bob exec_host=bob/0 sessio'
+                'n=22933 end=1398893780 Exit_status=0 resources_used.cput=00:00'
+                ':00 resources_used.mem=2580kb resources_used.vmem=37072kb reso'
+                'urces_used.walltime=00:03:20'),
+            'SGE': (
+                'dteam:testce.test:dteam:dteam041:STDIN:43:sge:19:1200093286:12'
+                '00093294:1200093295:0:0:1:0:0:0.000000:0:0:0:0:46206:0:0:0.0:0'
+                ':0:0:0:337:257:NONE:defaultdepartment:NONE:1:0:0.09:0.000213:0'
+                '.0:-U dteam -q dteam:0.0:NONE:30171136.0'),
+            'Slurm': (
+                '1007|c_61|dt5|dtm|2013-03-27T17:13:41|2013-03-27T17:13:44|00:0'
+                '0:03|3|prod|1|1|c-40|||COMPLETED'),
+        }
+
+        for test in tests:
+            parser_object = getattr(apel.parsers, test + 'Parser')
+            parser = parser_object('testSite', 'testHost', False)
+            self.assertTrue(parser.recognize(tests[test]), test)
+
+    def test_none(self):
+        """Check that parsers that can return None fail on appropriate lines."""
+        tests = {
+            'LSF': (
+                '"JOB_RESIZE" "5.1" 1089407406 699195 283 33554482 1 1089290023'
+                ' 0 0 1089406862 "raortega" "8nm" "" "" "" "lxplus015" "prog/st'
+                'ep3c" "" "/step3c-362.txt" "/berr-step3c-362.txt" "1089290023.'
+                '699195" 0 1 "tbed0079" 64 3.3 "" "/artEachset.j 362 7 8" 277.2'
+                '10000 17.280000 0 0 -1 0 0 927804 87722 0 0 0 -1 0 0 0 0 0 -1 '
+                '"" "default" 0 1 "" "" 0 310424 339112 "" "" ""'),
+            'PBS': '04/30/2014 15:33:00;S;5000.bob;the_rest',
+            'Slurm': (
+                '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|1'
+                '6||1|1|wn|28K|20K|BOOT_FAIL'),
+        }
+
+        for test in tests:
+            parser_object = getattr(apel.parsers, test + 'Parser')
+            parser = parser_object('testSite', 'testHost', False)
+            self.assertFalse(parser.recognize(tests[test]), test)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_parsers.py
+++ b/test/test_parsers.py
@@ -1,3 +1,5 @@
+"""Test cases for functionality given by base parser."""
+
 import unittest
 
 import apel.parsers
@@ -64,7 +66,13 @@ class AllParsersRecognizeTest(unittest.TestCase):
             self.assertTrue(parser.recognize(tests[test]), test)
 
     def test_none(self):
-        """Check that parsers that can return None fail on appropriate lines."""
+        """
+        Check that parsers that can return None fail on appropriate lines.
+
+        Only these parsers have the extra functionality to return None when they
+        parse a syntactically valid line that should be ignored e.g. unfinished.
+        The others either return the record or raise an exception.
+        """
         tests = {
             'LSF': (
                 '"JOB_RESIZE" "5.1" 1089407406 699195 283 33554482 1 1089290023'

--- a/test/test_parsers.py
+++ b/test/test_parsers.py
@@ -60,7 +60,7 @@ class AllParsersRecognizeTest(unittest.TestCase):
 
         for test in tests:
             parser_object = getattr(apel.parsers, test + 'Parser')
-            parser = parser_object('testSite', 'testHost', False)
+            parser = parser_object('testSite', 'testHost', True)
             self.assertTrue(parser.recognize(tests[test]), test)
 
     def test_none(self):
@@ -81,7 +81,7 @@ class AllParsersRecognizeTest(unittest.TestCase):
 
         for test in tests:
             parser_object = getattr(apel.parsers, test + 'Parser')
-            parser = parser_object('testSite', 'testHost', False)
+            parser = parser_object('testSite', 'testHost', True)
             self.assertFalse(parser.recognize(tests[test]), test)
 
 

--- a/test/test_record_factory.py
+++ b/test/test_record_factory.py
@@ -8,8 +8,9 @@ Tests for the RecordFactory.
 import unittest
 
 from apel.db.loader.record_factory import RecordFactory, RecordFactoryException
-from apel.db.records import JobRecord
-from apel.db.records import SummaryRecord
+from apel.db.records import (CloudRecord, CloudSummaryRecord, JobRecord,
+                             NormalisedSummaryRecord, StorageRecord,
+                             SummaryRecord, SyncRecord)
 
 
 class Test(unittest.TestCase):
@@ -23,27 +24,67 @@ class Test(unittest.TestCase):
         self.assertRaises(RecordFactoryException,
                           self._rf.create_records, self._rubbish_text)
 
+    def test_create_car(self):
+        """Check that creating a CAR record returns a JobRecord."""
+        record_list = self._rf.create_records(
+            '<urf:UsageRecord xmlns:urf="http://eu-emi.eu/namespaces/2012/11/co'
+            'mputerecord"></urf:UsageRecord>'
+        )
+        self.assertTrue(isinstance(record_list[0], JobRecord))
+
+    def test_create_aur(self):
+        """Check that trying to create an AUR record fails."""
+        self.assertRaises(RecordFactoryException, self._rf.create_records, (
+            '<aur:SummaryRecord xmlns:aur="http://eu-emi.eu/namespaces/2012/11'
+            '/aggregatedcomputerecord"></aur:SummaryRecord>')
+        )
+
+    def test_create_star(self):
+        """Check that creating a StAR record returns a StorageRecord."""
+        record_list = self._rf.create_records(
+            '<sr:StorageUsageRecord xmlns:sr="http://eu-emi.eu/namespaces/2011/'
+            '02/storagerecord"><sr:RecordIdentity sr:createTime="2016-06-09T02:'
+            '42:15Z" sr:recordId="c698"/></sr:StorageUsageRecord>'
+        )
+        self.assertTrue(isinstance(record_list[0], StorageRecord))
+
+    def test_create_bad_xml(self):
+        """Check that trying to create a record from non-record XML fials."""
+        self.assertRaises(RecordFactoryException, self._rf.create_records,
+                          '<nonrecordxml></nonrecordxml>')
+
+    def test_create_bad_apel(self):
+        """Check that an incorrect header raises an exception."""
+        self.assertRaises(RecordFactoryException, self._rf.create_records,
+                          'APEL-individual-bad-message: v0.1')
+
     def test_create_jrs(self):
-        try:
-            records = self._rf.create_records(self._jr_text)
-            if (len(records) != 2):
-                self.fail('Expected two records from record text.')
-            for record in records:
-                if not isinstance(record, JobRecord):
-                    self.fail('Expected JobRecord object.')
-        except Exception, e:
-            self.fail('Exception thrown when creating records from object: %s' % e)
+        records = self._rf.create_records(self._jr_text)
+        self.assertTrue(len(records), 2)
+        for record in records:
+            self.assertTrue(isinstance(record, JobRecord))
 
     def test_create_srs(self):
-        try:
-            records = self._rf.create_records(self._sr_text)
-            if (len(records) != 2):
-                self.fail('Expected two records from record text.')
-            for record in records:
-                if not isinstance(record, SummaryRecord):
-                    self.fail('Expected SummaryRecord object.')
-        except Exception, e:
-            self.fail('Exception thrown when creating records from object: %s' % e)
+        records = self._rf.create_records(self._sr_text)
+        self.assertTrue(len(records), 2)
+        for record in records:
+            self.assertTrue(isinstance(record, SummaryRecord))
+
+    def test_create_normalised_summary(self):
+        records = self._rf.create_records(self._nsr_text)
+        self.assertTrue(isinstance(records[0], NormalisedSummaryRecord))
+
+    def test_create_sync(self):
+        records = self._rf.create_records(self._sync_text)
+        self.assertTrue(isinstance(records[0], SyncRecord))
+
+    def test_create_cloud(self):
+        records = self._rf.create_records(self._cr_text)
+        self.assertTrue(isinstance(records[0], CloudRecord))
+
+    def test_create_cloud_summary(self):
+        records = self._rf.create_records(self._csr_text)
+        self.assertTrue(isinstance(records[0], CloudSummaryRecord))
 
     def _get_msg_text(self):
     # Below, I've just got some test data hard-coded.
@@ -116,6 +157,42 @@ CpuDuration: 2345
 NumberOfJobs: 100
 %%
 '''
+
+        self._nsr_text = '''APEL-summary-job-message: v0.3
+Site: RAL-LCG2
+Month: 3
+Year: 2010
+WallDuration: 234256
+CpuDuration: 244435
+NormalisedWallDuration: 234256
+NormalisedCpuDuration: 244435
+NumberOfJobs: 100
+%%
+'''
+
+        self._sync_text = '''APEL-sync-message: v0.1
+Site: RAL-LCG2
+Month: 3
+SubmitHost: sub.rl.ac.uk
+Year: 2010
+NumberOfJobs: 100
+%%
+'''
+
+        self._cr_text = '''APEL-cloud-message: v0.4
+VMUUID: 2013-11-14 19:15:21+00:00 CESNET vm-1
+SiteName: CESNET
+%%
+'''
+
+        self._csr_text = '''APEL-cloud-summary-message: v0.4
+SiteName: CESNET
+Month: 10
+Year: 2011
+NumberOfVMs: 1
+%%
+'''
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_record_factory.py
+++ b/test/test_record_factory.py
@@ -13,9 +13,11 @@ from apel.db.records import (CloudRecord, CloudSummaryRecord, JobRecord,
                              SummaryRecord, SyncRecord)
 
 
-class Test(unittest.TestCase):
+class TestRecordFactory(unittest.TestCase):
+    """Unit tests for the record factory class."""
 
     def setUp(self):
+        """Create message variables and record factory instance."""
         self._get_msg_text()
         self._rf = RecordFactory()
 
@@ -49,7 +51,7 @@ class Test(unittest.TestCase):
         self.assertTrue(isinstance(record_list[0], StorageRecord))
 
     def test_create_bad_xml(self):
-        """Check that trying to create a record from non-record XML fials."""
+        """Check that trying to create a record from non-record XML fails."""
         self.assertRaises(RecordFactoryException, self._rf.create_records,
                           '<nonrecordxml></nonrecordxml>')
 
@@ -59,30 +61,36 @@ class Test(unittest.TestCase):
                           'APEL-individual-bad-message: v0.1')
 
     def test_create_jrs(self):
+        """Check that creating job records returns JobRecords."""
         records = self._rf.create_records(self._jr_text)
         self.assertTrue(len(records), 2)
         for record in records:
             self.assertTrue(isinstance(record, JobRecord))
 
     def test_create_srs(self):
+        """Check that creating summary records returns SummaryRecords."""
         records = self._rf.create_records(self._sr_text)
         self.assertTrue(len(records), 2)
         for record in records:
             self.assertTrue(isinstance(record, SummaryRecord))
 
     def test_create_normalised_summary(self):
+        """Check that creating a normalised summary returns the right record."""
         records = self._rf.create_records(self._nsr_text)
         self.assertTrue(isinstance(records[0], NormalisedSummaryRecord))
 
     def test_create_sync(self):
+        """Check that creating a sync record returns a SyncRecord."""
         records = self._rf.create_records(self._sync_text)
         self.assertTrue(isinstance(records[0], SyncRecord))
 
     def test_create_cloud(self):
+        """Check that creating a cloud record returns a CloudRecord."""
         records = self._rf.create_records(self._cr_text)
         self.assertTrue(isinstance(records[0], CloudRecord))
 
     def test_create_cloud_summary(self):
+        """Check that creating a cloud summary returns a CloudSummaryRecord."""
         records = self._rf.create_records(self._csr_text)
         self.assertTrue(isinstance(records[0], CloudSummaryRecord))
 

--- a/test/test_record_factory.py
+++ b/test/test_record_factory.py
@@ -6,30 +6,22 @@ Created on 4 Jul 2011
 Tests for the RecordFactory.
 '''
 import unittest
+
 from apel.db.loader.record_factory import RecordFactory, RecordFactoryException
 from apel.db.records import JobRecord
 from apel.db.records import SummaryRecord
 
-class Test(unittest.TestCase):
 
+class Test(unittest.TestCase):
 
     def setUp(self):
         self._get_msg_text()
         self._rf = RecordFactory()
 
-
-    def tearDown(self):
-        pass
-
-
     def test_create_records(self):
-        
-        try:
-            self._rf.create_records(self._rubbish_text)
-            self.fail('No exception thrown by nonsense message.')
-        except RecordFactoryException:
-            # We expect the nonsense message to fail.
-            pass
+        """Check that a nonsense message raises an exception."""
+        self.assertRaises(RecordFactoryException,
+                          self._rf.create_records, self._rubbish_text)
 
     def test_create_jrs(self):
         try:
@@ -40,9 +32,8 @@ class Test(unittest.TestCase):
                 if not isinstance(record, JobRecord):
                     self.fail('Expected JobRecord object.')
         except Exception, e:
-            self.fail('Exception thrown when creating records from object: ' + str(e))
+            self.fail('Exception thrown when creating records from object: %s' % e)
 
-            
     def test_create_srs(self):
         try:
             records = self._rf.create_records(self._sr_text)
@@ -52,19 +43,17 @@ class Test(unittest.TestCase):
                 if not isinstance(record, SummaryRecord):
                     self.fail('Expected SummaryRecord object.')
         except Exception, e:
-            self.fail('Exception thrown when creating records from object: ' + str(e))
-            
-    
+            self.fail('Exception thrown when creating records from object: %s' % e)
+
     def _get_msg_text(self):
-    
     # Below, I've just got some test data hard-coded.
-        self._rubbish_text = '''In 1869, the stock ticker was invented. 
-        It was an electro-mechanical machine consisting of a typewriter, 
-        a long pair of wires and a ticker tape printer, 
-        and its purpose was to distribute stock prices over long 
-        distances in realtime. This concept gradually evolved into 
-        the faster, ASCII-based teletype.''' 
-    
+        self._rubbish_text = '''In 1869, the stock ticker was invented.
+        It was an electro-mechanical machine consisting of a typewriter,
+        a long pair of wires and a ticker tape printer,
+        and its purpose was to distribute stock prices over long
+        distances in realtime. This concept gradually evolved into
+        the faster, ASCII-based teletype.'''
+
         self._jr_text = '''\
 APEL-individual-job-message: v0.1
 Site: RAL-LCG2
@@ -101,8 +90,7 @@ MemoryVirtual: 2000
 ServiceLevelType: Si2k
 ServiceLevel: 1000
 %%'''
-    
-    
+
         self._sr_text = '''\
 APEL-summary-job-message: v0.2
 Site: RAL-LCG2

--- a/test/test_sge.py
+++ b/test/test_sge.py
@@ -120,7 +120,7 @@ class ParserSGETest(unittest.TestCase):
         Univa Grid Engine timestamps changed from seconds to milliseconds in
         version 8.2.0. This tests the new format accounting log.
         """
-        self.parser._ms_timestamps = True
+        self.parser.set_ms_timestamps(True)
 
         line = ("grid.q:node101.cm.cluster:atlas:atlas235:cream_814542935:38725"
                 "61:sge:0:1412932860657:1412932865141:1412933085629:0:0:220.488"
@@ -151,6 +151,16 @@ class ParserSGETest(unittest.TestCase):
             self.assertEqual(cont[key], values[key],
                              "%s != %s for key %s" % (cont[key], values[key],
                                                       key))
+
+    def test_set_ms_timestamp(self):
+        """Check that this method works as exepected."""
+        self.assertFalse(self.parser._ms_timestamps, "Non-default ms setting")
+
+        self.parser.set_ms_timestamps(True)
+        self.assertTrue(self.parser._ms_timestamps, "_ms_timestamps not set")
+
+        self.parser.set_ms_timestamps(False)
+        self.assertFalse(self.parser._ms_timestamps, "_ms_timestamps not unset")
 
     def test_parse_line_with_multiplier(self):
         '''
@@ -344,6 +354,18 @@ class ParserSGETest(unittest.TestCase):
                 self.assertEqual(d, parser._load_multipliers())
             finally:
                 patcher.stop()
+
+    def test_mpi_false(self):
+        """Check that non-mpi parsers return zero procs even if at least 1."""
+        line = ('dteam:testce.test:dteam:dteam041:STDIN:43:sge:19:1200093286:12'
+                '00093294:1200093295:0:0:1:0:0:0.000000:0:0:0:0:46206:0:0:0.0:0'
+                ':0:0:0:337:257:NONE:defaultdepartment:NONE:1:0:0.09:0.000213:0'
+                '.0:-U dteam -q dteam:0.0:NONE:30171136.0')
+        parser = apel.parsers.SGEParser('testSite', 'testHost', False)
+        record = parser.parse(line)
+        self.assertEqual(record._record_content['Processors'], 0,
+                         "Processors not zero for non-mpi parser")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_summary_record.py
+++ b/test/test_summary_record.py
@@ -102,8 +102,24 @@ class TestSummaryRecord(unittest.TestCase):
                 print values
                 self.fail('Values changed when creating a summary record: ' +
                           str(item1) + ": " + str(item2))
-                
-        
+
+    def test_get_ur(self):
+        """Check that get_ur outputs correct XML."""
+        sr = SummaryRecord()
+        sr.load_from_msg(self._records[0])
+        xml = ('<aur:SummaryRecord><aur:Site>RAL-LCG2</aur:Site><aur:Month>3</a'
+               'ur:Month><aur:Year>2010</aur:Year><aur:UserIdentity><urf:GroupA'
+               'ttribute urf:type="vo-group">/atlas</urf:GroupAttribute><urf:Gr'
+               'oupAttribute urf:type="vo-role">Role=production</urf:GroupAttri'
+               'bute></aur:UserIdentity><aur:SubmitHost>some.host.org</aur:Subm'
+               'itHost><aur:Infrastructure urf:type="grid"/><aur:EarliestEndTim'
+               'e>2010-03-01T01:00:00Z</aur:EarliestEndTime><aur:LatestEndTime>'
+               '2010-03-20T01:00:00Z</aur:LatestEndTime><aur:WallDuration>PT234'
+               '256S</aur:WallDuration><aur:CpuDuration>PT244435S</aur:CpuDurat'
+               'ion><aur:ServiceLevel urf:type="Si2k">1000.0</aur:ServiceLevel>'
+               '<aur:NumberOfJobs>100</aur:NumberOfJobs></aur:SummaryRecord>')
+        self.assertEqual(sr.get_ur(), xml)
+
 ############################################################################
 # Private helper method below
 ############################################################################


### PR DESCRIPTION
This fixes a couple of very minor things that aren't even really bugs, and is mainly adding extra unittests to the ones that were straightforward to do. I'll just list the non-test changes here:
- Fix spacing and capitalisation of constructed queries in `apeldb` module to be more consistent and match standard SQL.
- Add `HTCondorParser` to `__init__` imports.