### PR TITLE
Storage fixes

### DIFF
--- a/apel/db/backends/mysql.py
+++ b/apel/db/backends/mysql.py
@@ -53,7 +53,8 @@ class ApelMysqlDb(object):
                     CloudSummaryRecord : 'VCloudSummaries',
                     NormalisedSummaryRecord : 'VNormalisedSummaries',
                     ProcessedRecord : 'VProcessedFiles',
-                    SummaryRecord : 'VSummaries'}
+                    SummaryRecord : 'VSummaries',
+                    StorageRecord: 'VStarRecords'}
     
     # These simply need to have the same number of arguments as the stored procedures defined in the database schemas.
     INSERT_PROCEDURES = {

--- a/apel/db/records/storage.py
+++ b/apel/db/records/storage.py
@@ -175,6 +175,18 @@ class StorageRecord(Record):
             group_node.appendChild(doc.createTextNode(group_field))
             s_identity.appendChild(group_node)
 
+        if self.get_field('SubGroup') is not None:
+            sub_attr = doc.createElement('sr:GroupAttribute')
+            sub_attr.setAttribute('sr:attributeType', 'subgroup')
+            sub_attr.appendChild(doc.createTextNode(self.get_field('SubGroup')))
+            s_identity.appendChild(sub_attr)
+
+        if self.get_field('Role') is not None:
+            role_attr = doc.createElement('sr:GroupAttribute')
+            role_attr.setAttribute('sr:attributeType', 'role')
+            role_attr.appendChild(doc.createTextNode(self.get_field('Role')))
+            s_identity.appendChild(role_attr)
+
         # Append Subject Identity Block
         ur.appendChild(s_identity)
 

--- a/apel/db/records/storage.py
+++ b/apel/db/records/storage.py
@@ -67,9 +67,8 @@ class StorageRecord(Record):
         self._datetime_fields = ["CreateTime", "StartTime", "EndTime"]
         # Fields which will have an integer stored in them
         self._int_fields = ["FileCount", "ResourceCapacityUsed", "LogicalCapacityUsed", "ResourceCapacityAllocated"]
-        
-    
-    def get_apel_db_insert(self, apel_db, source):
+
+    def get_apel_db_insert(self, source=None):
         '''
         Returns record content as a tuple, appending the source of the record 
         (i.e. the sender's DN).  Also returns the appropriate stored procedure.
@@ -78,10 +77,9 @@ class StorageRecord(Record):
         This is because only this object knows what type of record it is,
         and only the apel_db knows what the procedure details are. 
         '''
-        
-        values = self.get_db_tuple(self, source)
-        
-        
+
+        values = self.get_db_tuple(source)
+
         return values
 
     def get_db_tuple(self, source=None):

--- a/apel/db/records/storage.py
+++ b/apel/db/records/storage.py
@@ -97,6 +97,7 @@ class StorageRecord(Record):
 
         Namespace information is written only once per record, by dbunloader.
         '''
+        del withhold_dns  # Unused
 
         doc = Document()
         ur = doc.createElement('sr:StorageUsageRecord')

--- a/conf/unloader.cfg
+++ b/conf/unloader.cfg
@@ -4,10 +4,13 @@ dir_location=/var/spool/apel/
 # The permitted tables are:
 # VJobRecords
 # VSummaries
-# VNormalisedSummaries
 # VSuperSummaries
+# VNormalisedSummaries
 # VNormalisedSuperSummaries
+# VSyncRecords
 # VCloudRecords
+# VCloudSummaries
+# VStarRecords
 table_name = VJobRecords
 
 # Only for job records and summaries

--- a/schemas/storage.sql
+++ b/schemas/storage.sql
@@ -337,17 +337,35 @@ BEGIN
 END //
 DELIMITER ;
 
--- ------------------------------------------------------------------------------
+-- -----------------------------------------------------------------------------
 -- VStarRecords
 DROP VIEW IF EXISTS VStarRecords;
-CREATE VIEW VStarRecords 
-AS select CreateTime, RecordId, StorageSystems.name AS StorageSystem, Sites.name AS Site, StorageShares.name AS StorageShare, StorageMedia.name AS StorageMedia, StorageClasses.name AS StorageClass, FileCount, DirectoryPath, LocalUser, LocalGroup, UserIdentities.name AS UserIdentity, Groups.name AS `Group`, StartTime, EndTime, ResourceCapacityUsed, LogicalCapacityUsed, ResourceCapacityAllocated 
-from StarRecords, StorageSystems, Sites, StorageShares, StorageMedia, StorageClasses, UserIdentities, Groups
-where StarRecords.StorageSystemID = StorageSystems.id 
-AND StarRecords.SiteID = Sites.id
-AND StarRecords.StorageShareID = StorageShares.id
-AND StarRecords.StorageMediaID = StorageMedia.id
-AND StarRecords.StorageClassID = StorageClasses.id
-AND StarRecords.UserIdentityID = UserIdentities.id
-AND StarRecords.GroupID = Groups.id;
 
+CREATE VIEW VStarRecords AS
+SELECT CreateTime,
+       RecordId,
+       StorageSystems.name AS StorageSystem,
+       Sites.name AS Site,
+       StorageShares.name AS StorageShare,
+       StorageMedia.name AS StorageMedia,
+       StorageClasses.name AS StorageClass,
+       FileCount,
+       DirectoryPath,
+       LocalUser,
+       LocalGroup,
+       UserIdentities.name AS UserIdentity,
+       Groups.name AS `Group`,
+       StartTime,
+       EndTime,
+       ResourceCapacityUsed,
+       LogicalCapacityUsed,
+       ResourceCapacityAllocated 
+FROM StarRecords, StorageSystems, Sites, StorageShares,
+     StorageMedia, StorageClasses, UserIdentities, Groups
+WHERE StarRecords.StorageSystemID = StorageSystems.id
+  AND StarRecords.SiteID = Sites.id
+  AND StarRecords.StorageShareID = StorageShares.id
+  AND StarRecords.StorageMediaID = StorageMedia.id
+  AND StarRecords.StorageClassID = StorageClasses.id
+  AND StarRecords.UserIdentityID = UserIdentities.id
+  AND StarRecords.GroupID = Groups.id;

--- a/schemas/storage.sql
+++ b/schemas/storage.sql
@@ -355,17 +355,22 @@ SELECT CreateTime,
        LocalGroup,
        UserIdentities.name AS UserIdentity,
        Groups.name AS `Group`,
+       Roles.name AS `Role`,
+       SubGroups.name AS SubGroup,
        StartTime,
        EndTime,
        ResourceCapacityUsed,
        LogicalCapacityUsed,
        ResourceCapacityAllocated 
 FROM StarRecords, StorageSystems, Sites, StorageShares,
-     StorageMedia, StorageClasses, UserIdentities, Groups
+     StorageMedia, StorageClasses, UserIdentities, Groups,
+     SubGroups, Roles
 WHERE StarRecords.StorageSystemID = StorageSystems.id
   AND StarRecords.SiteID = Sites.id
   AND StarRecords.StorageShareID = StorageShares.id
   AND StarRecords.StorageMediaID = StorageMedia.id
   AND StarRecords.StorageClassID = StorageClasses.id
   AND StarRecords.UserIdentityID = UserIdentities.id
-  AND StarRecords.GroupID = Groups.id;
+  AND StarRecords.GroupID = Groups.id
+  AND StarRecords.SubGroupID = SubGroups.id
+  AND StarRecords.RoleID = Roles.id;

--- a/schemas/storage.sql
+++ b/schemas/storage.sql
@@ -336,3 +336,18 @@ BEGIN
         );
 END //
 DELIMITER ;
+
+-- ------------------------------------------------------------------------------
+-- VStarRecords
+DROP VIEW IF EXISTS VStarRecords;
+CREATE VIEW VStarRecords 
+AS select CreateTime, RecordId, StorageSystems.name AS StorageSystem, Sites.name AS Site, StorageShares.name AS StorageShare, StorageMedia.name AS StorageMedia, StorageClasses.name AS StorageClass, FileCount, DirectoryPath, LocalUser, LocalGroup, UserIdentities.name AS UserIdentity, Groups.name AS `Group`, StartTime, EndTime, ResourceCapacityUsed, LogicalCapacityUsed, ResourceCapacityAllocated 
+from StarRecords, StorageSystems, Sites, StorageShares, StorageMedia, StorageClasses, UserIdentities, Groups
+where StarRecords.StorageSystemID = StorageSystems.id 
+AND StarRecords.SiteID = Sites.id
+AND StarRecords.StorageShareID = StorageShares.id
+AND StarRecords.StorageMediaID = StorageMedia.id
+AND StarRecords.StorageClassID = StorageClasses.id
+AND StarRecords.UserIdentityID = UserIdentities.id
+AND StarRecords.GroupID = Groups.id;
+

--- a/scripts/update-1.5.1-1.6.0.sql
+++ b/scripts/update-1.5.1-1.6.0.sql
@@ -1,11 +1,20 @@
--- This script is a single comment block that applies to
--- APEL Version 1.5.1, Cloud Database.
+-- This script contains multiple comment blocks that can update
+-- APEL version 1.5.1 databases of the following types to 1.6.0:
+--  - Cloud Accounting Database
+--  - Storage Accounting Database
 
--- If you have a Cloud Database and wish to
--- upgrade to APEL Version 1.6.0, remove the block comment
--- symbols /* and */ and run this script
+-- To update, find the relevent comment block below and remove
+-- its block comment symbols /* and */ then run this script.
+
+
    
 /*
+-- UPDATE SCRIPT FOR CLOUD SCHEMA
+
+-- If you have a Cloud Accounting Database and wish to
+-- upgrade to APEL Version 1.6.0, remove the block comment
+-- symbols around this section and then run this script.
+
 -- Create / Update Tables
 
 -- Update CloudRecords
@@ -211,4 +220,146 @@ BEGIN
     ORDER BY NULL;
 END //
 DELIMITER ;
+*/
+
+
 /*
+-- UPDATE SCRIPT FOR STORAGE SCHEMA
+
+-- If you have a Storage Accounting Database and wish to
+-- upgrade to APEL version 1.6.0, remove the block comment
+-- symbols around this section and then run this script.
+
+-- This script adds tables SubGroups and Roles, and two matching Lookup tables.
+-- It then adds defualt values to first two tables, expands the StarRecords
+-- table with two matching ID columns, then sets those to default values. Lastly
+-- the ReplaceStarRecord is updated to include the new fields.
+
+
+DROP TABLE IF EXISTS SubGroups;
+CREATE TABLE SubGroups (
+  id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255),
+  INDEX (name)
+);
+
+DROP FUNCTION IF EXISTS SubGroupLookup;
+DELIMITER //
+CREATE FUNCTION SubGroupLookup(lookup VARCHAR(255)) RETURNS INTEGER DETERMINISTIC
+BEGIN
+  DECLARE result INTEGER;
+  SELECT id FROM SubGroups WHERE name=lookup INTO result;
+  IF result IS NULL THEN
+    INSERT INTO SubGroups(name) VALUES (lookup);
+    SET result=LAST_INSERT_ID();
+  END IF;
+RETURN result;
+END //
+DELIMITER ;
+
+
+DROP TABLE IF EXISTS Roles;
+CREATE TABLE Roles (
+  id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255),
+  INDEX (name)
+);
+
+DROP FUNCTION IF EXISTS RoleLookup;
+DELIMITER //
+CREATE FUNCTION RoleLookup(lookup VARCHAR(255)) RETURNS INTEGER DETERMINISTIC
+BEGIN
+  DECLARE result INTEGER;
+  SELECT id FROM Roles WHERE name=lookup INTO result;
+  IF result IS NULL THEN
+    INSERT INTO Roles(name) VALUES (lookup);
+    SET result=LAST_INSERT_ID();
+  END IF;
+RETURN result;
+END //
+DELIMITER ;
+
+
+INSERT INTO SubGroups VALUES(1,'None');
+INSERT INTO Roles VALUES(1,'None');
+
+
+ALTER TABLE StarRecords
+  ADD COLUMN SubGroupID INT NOT NULL AFTER GroupID,
+  ADD COLUMN RoleID INT NOT NULL AFTER SubGroupID;
+
+Update StarRecords SET SubGroupID=1;
+Update StarRecords SET RoleID=1;
+
+
+DROP PROCEDURE IF EXISTS ReplaceStarRecord;
+DELIMITER //
+CREATE PROCEDURE ReplaceStarRecord(
+  recordId                  VARCHAR(255),
+  createTime                DATETIME,
+  storageSystem             VARCHAR(255),
+  site                      VARCHAR(255),
+  storageShare              VARCHAR(255),
+  storageMedia              VARCHAR(255),
+  storageClass              VARCHAR(255),
+  fileCount                 INTEGER,
+  directoryPath             VARCHAR(255),
+  localUser                 VARCHAR(255),
+  localGroup                VARCHAR(255),
+  userIdentity              VARCHAR(255),
+  groupName                 VARCHAR(255),
+  subGroupName              VARCHAR(255),
+  roleName                  VARCHAR(255),
+  startTime                 DATETIME,
+  endTime                   DATETIME,
+  resourceCapacityUsed      BIGINT,
+  logicalCapacityUsed       BIGINT,
+  resourceCapacityAllocated BIGINT
+)
+BEGIN
+  REPLACE INTO StarRecords(
+    RecordId,
+    CreateTime,
+    StorageSystemID,
+    SiteID,
+    StorageShareID,
+    StorageMediaID,
+    StorageClassID,
+    FileCount,
+    DirectoryPath,
+    LocalUser,
+    LocalGroup,
+    UserIdentityID,
+    GroupID,
+    SubGroupID,
+    RoleID,
+    StartTime,
+    EndTime,
+    ResourceCapacityUsed,
+    LogicalCapacityUsed,
+    ResourceCapacityAllocated)
+  VALUES (
+    recordId,
+    createTime,
+    StorageSystemLookup(storageSystem),
+    SiteLookup(site),
+    StorageShareLookup(storageShare),
+    StorageMediaLookup(storageMedia),
+    StorageClassLookup(storageClass),
+    fileCount,
+    directoryPath,
+    localUser,
+    localGroup,
+    UserIdentityLookup(userIdentity),
+    GroupLookup(groupName),
+    SubGroupLookup(subGroupName),
+    RoleLookup(roleName),
+    startTime,
+    endTime,
+    resourceCapacityUsed,
+    logicalCapacityUsed,
+    resourceCapacityAllocated
+);
+END //
+DELIMITER ;
+*/

--- a/scripts/update-1.6.0-next.sql
+++ b/scripts/update-1.6.0-next.sql
@@ -1,8 +1,12 @@
--- This script is contains multiple comments block that apply to
--- APEL Version 1.6.0, and the following databases:
+-- This script contains multiple comment blocks that can update
+-- APEL version 1.6.0 databases of the following types:
 --  - Client Grid Accounting Database
 --  - Server Grid Accounting Database
 --  - Cloud Accounting Database
+--  - Storage Accounting Database
+
+-- To update, find the relevent comment block below and remove
+-- its block comment symbols /* and */ then run this script.
 
 /*
 -- UPDATE SCRIPT FOR CLIENT SCHEMA
@@ -25,6 +29,7 @@ ALTER TABLE SuperSummaries MODIFY COLUMN UpdateTime TIMESTAMP NOT NULL DEFAULT C
 UPDATE LastUpdated SET UpdateTime = '0000-00-00 00:00:00' WHERE UpdateTime IS NULL;
 ALTER TABLE LastUpdated MODIFY COLUMN UpdateTime TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
 */
+
 
 /*
 -- UPDATE SCRIPT FOR SERVER SCHEMA
@@ -57,6 +62,7 @@ UPDATE LastUpdated SET UpdateTime = '0000-00-00 00:00:00' WHERE UpdateTime IS NU
 ALTER TABLE LastUpdated MODIFY COLUMN UpdateTime TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
 */
 
+
 /*
 -- UPDATE SCRIPT FOR CLOUD SCHEMA
 
@@ -77,4 +83,51 @@ ALTER TABLE CloudSummaries MODIFY COLUMN UpdateTime TIMESTAMP NOT NULL DEFAULT C
 
 UPDATE LastUpdated SET UpdateTime = '0000-00-00 00:00:00' WHERE UpdateTime IS NULL;
 ALTER TABLE LastUpdated MODIFY COLUMN UpdateTime TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+*/
+
+
+/*
+-- UPDATE SCRIPT FOR STORAGE SCHEMA
+
+-- If you have a Storage Accounting Database and wish to
+-- upgrade to the next APEL version, remove the block comment
+-- symbols around this section and then run this script.
+
+-- This script adds the VStarRecords view.
+
+DROP VIEW IF EXISTS VStarRecords;
+
+CREATE VIEW VStarRecords AS
+SELECT CreateTime,
+       RecordId,
+       StorageSystems.name AS StorageSystem,
+       Sites.name AS Site,
+       StorageShares.name AS StorageShare,
+       StorageMedia.name AS StorageMedia,
+       StorageClasses.name AS StorageClass,
+       FileCount,
+       DirectoryPath,
+       LocalUser,
+       LocalGroup,
+       UserIdentities.name AS UserIdentity,
+       Groups.name AS `Group`,
+       Roles.name AS `Role`,
+       SubGroups.name AS SubGroup,
+       StartTime,
+       EndTime,
+       ResourceCapacityUsed,
+       LogicalCapacityUsed,
+       ResourceCapacityAllocated 
+FROM StarRecords, StorageSystems, Sites, StorageShares,
+     StorageMedia, StorageClasses, UserIdentities, Groups,
+     SubGroups, Roles
+WHERE StarRecords.StorageSystemID = StorageSystems.id
+  AND StarRecords.SiteID = Sites.id
+  AND StarRecords.StorageShareID = StorageShares.id
+  AND StarRecords.StorageMediaID = StorageMedia.id
+  AND StarRecords.StorageClassID = StorageClasses.id
+  AND StarRecords.UserIdentityID = UserIdentities.id
+  AND StarRecords.GroupID = Groups.id
+  AND StarRecords.SubGroupID = SubGroups.id
+  AND StarRecords.RoleID = Roles.id;
 */

--- a/test/test_storage_record.py
+++ b/test/test_storage_record.py
@@ -110,6 +110,7 @@ class StorageRecordTest(unittest.TestCase):
 
         parser = StarParser(XML_HEADER + UR_OPEN + ur + UR_CLOSE)
 
+        # This works as all dictionary values are hashable/immutable
         missmatched = (set(parser.get_records()[0]._record_content.items()) ^
                        set(record._record_content.items()))
         for item in list(missmatched):

--- a/test/test_storage_record.py
+++ b/test/test_storage_record.py
@@ -79,6 +79,25 @@ class StorageRecordTest(unittest.TestCase):
         record.get_apel_db_insert()
         record.get_apel_db_insert(None)
 
+    def test_get_ur(self):
+        """Check that al input values are present in XML output of get_ur"""
+
+        data = ('host.example.org/sr/87912469269276', 1289293612,
+                'host.example.org', 'MySite', 'pool-003', 'disk', 'replicated',
+                42, '/home/projectA', 'johndoe', 'projectA',
+                '/O=Grid/OU=example.org/CN=John Doe',
+                'binarydataproject.example.org', 'uk', 'poweruser',
+                '2010-10-11T09:31:40Z', '2010-10-11T09:41:40Z', 14728, 13617, 0)
+
+        record = StorageRecord()
+        record.load_from_tuple(data)
+        ur = record.get_ur()
+
+        for value in data:
+            # Skip the createTime value as it's regenerated when calling get_ur
+            if value != 1289293612 and str(value) not in ur:
+                self.fail("Input value '%s' not found in XML output." % value)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_storage_record.py
+++ b/test/test_storage_record.py
@@ -61,6 +61,24 @@ class StorageRecordTest(unittest.TestCase):
         except Exception, e:
             self.fail('_check_fields method failed: %s [%s]' % (str(e), str(type(e))))
 
+    def test_get_apel_db_insert(self):
+        """Check that calling get_apel_db_insert raises no exceptions
+
+        Previously there was a mismatch between the number of arguments of this
+        and the parent Record class which led to a TypeError being raised.
+        """
+
+        record = StorageRecord()
+        record.set_field('RecordId', 'host.example.org/sr/87912469269276')
+        record.set_field('CreateTime', 1289293612)
+        record.set_field('StorageSystem', 'host.example.org')
+        record.set_field('StartTime', 1286785900)
+        record.set_field('EndTime', 1286786500)
+        record.set_field('ResourceCapacityUsed', 14728)
+
+        record.get_apel_db_insert()
+        record.get_apel_db_insert(None)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_unloader.py
+++ b/test/test_unloader.py
@@ -18,19 +18,20 @@ class TestDbUnloader(unittest.TestCase):
         self.dir_path = tempfile.mkdtemp()
         self.unloader = DbUnloader(None, self.dir_path)
 
+    def tearDown(self):
+        shutil.rmtree(self.dir_path)
+
     def test_write_star_to_apel(self):
         """Check that unloading StAR records to APEL format is prevented."""
         self.assertRaises(ApelDbException, self.unloader._write_messages,
                           StorageRecord, 'table', 'query', ur=False)
 
-    def tearDown(self):
-        shutil.rmtree(self.dir_path)
-
 
 class TestFunctions(unittest.TestCase):
+    """Test cases for non-class functions."""
 
     def test_get_start_of_previous_month(self):
-
+        """Check that get_start_of_previous_month gives the correct datetime."""
         dt = datetime.datetime(2012, 1, 1, 1, 1, 1)
         dt2 = datetime.datetime(2011, 12, 1, 0, 0, 0)
         ndt = get_start_of_previous_month(dt)

--- a/test/test_unloader.py
+++ b/test/test_unloader.py
@@ -1,24 +1,45 @@
-from apel.db.unloader import DbUnloader, get_start_of_previous_month
 import datetime
-from unittest import TestCase
+import shutil
+import tempfile
+import unittest
 
-class TestDbUnloader(TestCase):
+from apel.db.apeldb import ApelDbException
+from apel.db.records import StorageRecord
+from apel.db.unloader import DbUnloader, get_start_of_previous_month
+
+
+class TestDbUnloader(unittest.TestCase):
     '''
     Test case for DbUnloader.
     '''
-    
+
     def setUp(self):
-        db = None
-        #self.unloader = DbUnloader(db, '/tmp')
-    
+        # Create temporary directory for dirq to write to
+        self.dir_path = tempfile.mkdtemp()
+        self.unloader = DbUnloader(None, self.dir_path)
+
+    def test_write_star_to_apel(self):
+        """Check that unloading StAR records to APEL format is prevented."""
+        self.assertRaises(ApelDbException, self.unloader._write_messages,
+                          StorageRecord, 'table', 'query', ur=False)
+
+    def tearDown(self):
+        shutil.rmtree(self.dir_path)
+
+
+class TestFunctions(unittest.TestCase):
+
     def test_get_start_of_previous_month(self):
-        
-        dt = datetime.datetime(2012,1,1,1,1,1)
-        dt2 = datetime.datetime(2011,12,1,0,0,0)
+
+        dt = datetime.datetime(2012, 1, 1, 1, 1, 1)
+        dt2 = datetime.datetime(2011, 12, 1, 0, 0, 0)
         ndt = get_start_of_previous_month(dt)
         self.assertEqual(dt2, ndt)
-        
-        dt3 = datetime.datetime(2012,3,1,1,1,1)
-        dt4 = datetime.datetime(2012,2,1,0,0,0)
+
+        dt3 = datetime.datetime(2012, 3, 1, 1, 1, 1)
+        dt4 = datetime.datetime(2012, 2, 1, 0, 0, 0)
         ndt = get_start_of_previous_month(dt3)
         self.assertEqual(dt4, ndt)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Resolves #108, resolves #109.

Changes in this PR:

- Add bits to unloader to enable unloading of StAR records in XML format.
- Add `VStarRecords` view.
- Extend the two update schemas to enable migration of old storage accounting databases.

The update schema changes were tested by creating a database for each version (1.5.1, 1.6.0, 1.6.1), running the relevant update script on them, then dumping the database and diffing the output (ignoring whitespace).

```
# mysqldump --skip-comments --skip-extended-insert --routines -u root v151 > v151.sql

# diff -w v151.sql 161new.sql
```

No significant differences between all three, though the two databases that had been updated had the additional default values in the `Roles` and `SubGroups` tables (as per the update schema) and so, interestingly, the table properties for them included `AUTO_INCREMENT=2` which sets the initial `AUTO_INCREMENT` value for the table to 2 (one more than the default value).