### PR TITLE
Add a PID check to the summariser and corresponding unit test 

### DIFF
--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -63,8 +63,8 @@ def runprocess(db_config_file, config_file, log_config_file):
 
     # set up logging
     try:
-        if os.path.exists(options.log_config):
-            logging.config.fileConfig(options.log_config)
+        if os.path.exists(log_config_file):
+            logging.config.fileConfig(log_config_file)
         else:
             set_up_logging(cp.get('logging', 'logfile'), 
                            cp.get('logging', 'level'),

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -98,6 +98,7 @@ def runprocess(db_config_file, config_file, log_config_file):
         # If we fail to create a pidfile, don't start the summariser
         sys.exit(1)
 
+    log.info('Created Pidfile')
     # Log into the database
     try:
 

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -130,7 +130,16 @@ def runprocess(db_config_file, config_file, log_config_file):
         # Clean up pidfile regardless of any excpetions
         # This even executes if sys.exit() is called
         log.info('Removing Pidfile')
-        os.remove(pidfile)
+        try:
+            if os.path.exists(pidfile):
+                os.remove(pidfile)
+            else:
+                log.warn("pidfile %s not found.", pidfile)
+
+        except IOError, e:
+            log.warn("Failed to remove pidfile %s: %s", pidfile, e)
+            log.warn("The summariser may not start again until it is removed.")
+
         log.info(LOG_BREAK)
         
 

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -139,7 +139,6 @@ def runprocess(db_config_file, config_file, log_config_file):
             log.warn("The summariser may not start again until it is removed.")
 
         log.info(LOG_BREAK)
-        
 
 
 if __name__ == '__main__':
@@ -156,4 +155,3 @@ if __name__ == '__main__':
     (options,args) = opt_parser.parse_args()
     
     runprocess(options.db, options.config, options.log_config)
-

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -86,7 +86,7 @@ def runprocess(db_config_file, config_file, log_config_file):
             log.warn("Check that the summariser is not running, then remove the file.")
             raise Exception("The summariser cannot start while pidfile exists.")
     except Exception, err:
-        print "Error initialising summariser: " + err
+        print "Error initialising summariser: %s" % err
         sys.exit(1)
     try:
         f = open(pidfile, "w")

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -124,8 +124,14 @@ def runprocess(db_config_file, config_file, log_config_file):
     except ApelDbException, err:
         log.error('Error summarising: ' + str(err))
         log.error('Summarising has been cancelled.')
-        log.info(LOG_BREAK)
         sys.exit(1)
+    finally:
+        # Clean up pidfile regardless of any excpetions
+        # This even executes if sys.exit() is called
+        log.info('Removing Pidfile')
+        os.remove(pidfile)
+        log.info(LOG_BREAK)
+        
 
 
 if __name__ == '__main__':

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -95,6 +95,8 @@ def runprocess(db_config_file, config_file, log_config_file):
         f.close()
     except IOError, e:
         log.warn("Failed to create pidfile %s: %s", pidfile, e)
+        # If we fail to create a pidfile, don't start the summariser
+        sys.exit(1)
 
     # Log into the database
     try:

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -83,8 +83,8 @@ def runprocess(db_config_file, config_file, log_config_file):
             error = "Cannot start summariser.  Pidfile %s already exists." % pidfile
 
             log.error("A pidfile %s already exists.", pidfile)
-            log.warn("Check that the dbloader is not running, then remove the file.")
-            raise Exception("The dbloader cannot start while pidfile exists.")
+            log.warn("Check that the summariser is not running, then remove the file.")
+            raise Exception("The summariser cannot start while pidfile exists.")
     except Exception, err:
         print "Error initialising summariser: " + err
         sys.exit(1)

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -80,8 +80,6 @@ def runprocess(db_config_file, config_file, log_config_file):
     # If the pidfile exists, don't start up.
     try:
         if os.path.exists(pidfile):
-            error = "Cannot start summariser.  Pidfile %s already exists." % pidfile
-
             log.error("A pidfile %s already exists.", pidfile)
             log.warn("Check that the summariser is not running, then remove the file.")
             raise Exception("The summariser cannot start while pidfile exists.")

--- a/conf/summariser.cfg
+++ b/conf/summariser.cfg
@@ -1,3 +1,7 @@
+[summariser]
+# Location of the pidfile
+pidfile = /var/run/apel/summariser.pid
+
 [logging]
 logfile = /var/log/apel/summariser.log
 level = INFO

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,5 @@
 # Constraints that apply to pip installed requirements
 
-# coveralls dependency that needs an older version for Python 2.6
+# coveralls dependencies that need older versions for Python 2.6
 pycparser<2.19
+idna<2.8

--- a/test/test_summariser.py
+++ b/test/test_summariser.py
@@ -1,0 +1,102 @@
+"""This file contains the BinSummariserTest class."""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from subprocess import Popen, PIPE
+
+
+class BinSummariserTest(unittest.TestCase):
+    """A class to test the bin/summariser.py file."""
+
+    def setUp(self):
+        """Create tempory config files and populate the db config."""
+        # Create a directory for temporary files
+        self._tmp_dir = tempfile.mkdtemp(prefix='summariser')
+
+        # Create an empty database config file
+        self.db_cfg, self.db_cfg_path = tempfile.mkstemp(prefix='db',
+                                                         dir=self._tmp_dir)
+
+        # Create an empty summariser config file
+        self.sum_cfg, self.sum_cfg_path = tempfile.mkstemp(prefix='sum',
+                                                           dir=self._tmp_dir)
+
+        # Populate the database config (with junk)
+        os.write(self.db_cfg, DB_CONF)
+        os.close(self.db_cfg)
+
+    def test_lock_file(self):
+        """Test a existing Pidfile prevents a summariser from starting."""
+        # Create the Pidfile.
+        # We don't have to worry about cleaning it up as tearDown deletes
+        # everything in self._tmp_dir
+        _pid_file, pid_path = tempfile.mkstemp(prefix='pid',
+                                               dir=self._tmp_dir)
+
+        # Create a temporary summariser config that refers to the Pidfile above
+        sum_conf = ('[summariser]\n'
+                    'pidfile = %s\n'
+                    '\n'
+                    '[logging]\n'
+                    'logfile = /tmp/apel/summariser.log\n'
+                    'level = INFO\n'
+                    'console = true\n' % pid_path)
+
+        # Write temporary config to the temporary file
+        os.write(self.sum_cfg, sum_conf)
+        os.close(self.sum_cfg)
+
+        # Run the summariser with the temporary config files
+        summariser = Popen(['python', 'bin/summariser.py',
+                            '-d', self.db_cfg_path,
+                            '-c', self.sum_cfg_path],
+                           stdout=PIPE)
+
+        output, error = summariser.communicate()
+
+        if error is not None:
+            # Then it errored in some unforseen way
+            self.fail(error)
+
+        if 'pidfile exists' not in output:
+            if 'Created Pidfile' in output:
+                # Then we have errored in an expected way
+                # and a summariser was started
+                self.fail('A summariser started despite existing pidfile.')
+            else:
+                # Something else has happened.
+                self.fail('An unexpected summariser error has occured.')
+
+    def tearDown(self):
+        """Remove test directory and all contents."""
+        try:
+            shutil.rmtree(self._tmp_dir)
+        except OSError, error:
+            print 'Error removing temporary directory %s' % self._tmp_dir
+            print error
+
+DB_CONF = """[db]
+# type of database
+backend = Tutorial D
+# host with database
+hostname = Darwen
+# port to connect to
+port = 3306
+# database name
+name = hugh
+# database user
+username = hugh
+# password for database
+password = duck
+# how many records should be put/fetched to/from database
+# in single query
+records = 1000
+# option for summariser so that SummariseVMs is called
+type = birds
+"""
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_summariser.py
+++ b/test/test_summariser.py
@@ -47,7 +47,7 @@ class BinSummariserTest(unittest.TestCase):
                     '[logging]\n'
                     'logfile = %s\n'
                     'level = INFO\n'
-                    'console = true\n' % (sum_log_path, pid_path))
+                    'console = true\n' % (pid_path, sum_log_path))
 
         # Write temporary config to the temporary file
         os.write(self.sum_cfg, sum_conf)

--- a/test/test_summariser.py
+++ b/test/test_summariser.py
@@ -36,14 +36,18 @@ class BinSummariserTest(unittest.TestCase):
         _pid_file, pid_path = tempfile.mkstemp(prefix='pid',
                                                dir=self._tmp_dir)
 
+        # Create a temporary log file for the summariser
+        _sum_log, sum_log_path = tempfile.mkstemp(prefix='sum',
+                                                  dir=self._tmp_dir)
+
         # Create a temporary summariser config that refers to the Pidfile above
         sum_conf = ('[summariser]\n'
                     'pidfile = %s\n'
                     '\n'
                     '[logging]\n'
-                    'logfile = /tmp/apel/summariser.log\n'
+                    'logfile = %s\n'
                     'level = INFO\n'
-                    'console = true\n' % pid_path)
+                    'console = true\n' % (sum_log_path, pid_path))
 
         # Write temporary config to the temporary file
         os.write(self.sum_cfg, sum_conf)

--- a/test/test_summariser.py
+++ b/test/test_summariser.py
@@ -68,7 +68,9 @@ class BinSummariserTest(unittest.TestCase):
                 self.fail('A summariser started despite existing pidfile.')
             else:
                 # Something else has happened.
-                self.fail('An unexpected summariser error has occured.')
+                self.fail('An unexpected summariser error has occured.\n'
+                          'See output below:\n'
+                          '%s' % output)
 
     def tearDown(self):
         """Remove test directory and all contents."""

--- a/test/test_summariser.py
+++ b/test/test_summariser.py
@@ -47,7 +47,7 @@ class BinSummariserTest(unittest.TestCase):
                     '[logging]\n'
                     'logfile = %s\n'
                     'level = INFO\n'
-                    'console = true\n' % (pid_path, sum_log_path))
+                    'console = false\n' % (pid_path, sum_log_path))
 
         # Write temporary config to the temporary file
         os.write(self.sum_cfg, sum_conf)

--- a/test/test_summariser.py
+++ b/test/test_summariser.py
@@ -50,7 +50,7 @@ class BinSummariserTest(unittest.TestCase):
         os.close(self.sum_cfg)
 
         # Run the summariser with the temporary config files
-        summariser = Popen(['python', 'bin/summariser.py',
+        summariser = Popen(['python', '../bin/summariser.py',
                             '-d', self.db_cfg_path,
                             '-c', self.sum_cfg_path],
                            stdout=PIPE)


### PR DESCRIPTION
Resolves #79 

Add a PID check to the summariser so that two summarisers of the same type can't be run at the same time. If the summariser finds it's Pidfile already exists, or it fails to create a new Pidfile, the summariser will now not run. At then end of the summariser run it tries to clean up the Pidfile and logs if the clean up fails.

Also adds a unit test of `bin/summariser.py` to test this new added functionality. This required a change to `bin/summariser.py` as `runprocess()` previously could not be run without running the python script.