### PR TITLE
Add remaining fields that are in the cloud summariser 'GROUP BY' statement to the primary key

### DIFF
--- a/schemas/cloud.sql
+++ b/schemas/cloud.sql
@@ -114,7 +114,7 @@ CREATE TABLE CloudSummaries (
   LatestStartTime DATETIME,
   WallDuration BIGINT,
   CpuDuration BIGINT,
-  CpuCount INT,
+  CpuCount INT NOT NULL,
 
   NetworkInbound BIGINT,
   NetworkOutbound BIGINT,
@@ -129,7 +129,7 @@ CREATE TABLE CloudSummaries (
   
   PublisherDNID VARCHAR(255),
 
-  PRIMARY KEY (SiteID, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId)
+  PRIMARY KEY (SiteID, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId, CpuCount)
 
 );
 

--- a/schemas/cloud.sql
+++ b/schemas/cloud.sql
@@ -129,7 +129,9 @@ CREATE TABLE CloudSummaries (
   
   PublisherDNID VARCHAR(255),
 
-  PRIMARY KEY (SiteID, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId, CpuCount)
+  PRIMARY KEY (SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID,
+    VOID, VOGroupID, VORoleID, Status, CloudType, ImageId, CpuCount,
+    BenchmarkType, Benchmark)
 
 );
 

--- a/schemas/cloud.sql
+++ b/schemas/cloud.sql
@@ -106,9 +106,9 @@ CREATE TABLE CloudSummaries (
   VOGroupID INT NOT NULL, -- Foreign key
   VORoleID INT NOT NULL, -- Foreign key
 
-  Status VARCHAR(255),
-  CloudType VARCHAR(255),
-  ImageId VARCHAR(255),
+  Status VARCHAR(255) NOT NULL,
+  CloudType VARCHAR(255) NOT NULL,
+  ImageId VARCHAR(255) NOT NULL,
 
   EarliestStartTime DATETIME,
   LatestStartTime DATETIME,

--- a/scripts/update-1.6.0-next.sql
+++ b/scripts/update-1.6.0-next.sql
@@ -88,11 +88,11 @@ ALTER TABLE LastUpdated MODIFY COLUMN UpdateTime TIMESTAMP NOT NULL DEFAULT CURR
 -- GROUP BY statement in the summariser to the CloudSummaries
 -- table primary key.
 -- If it is grouped on as part of the summariser,
--- it should be part of the primary key
+-- it should be part of the primary key.
 
--- it's possible CpuCount could be NULL, and to add it to the
--- primary key the cloumn has to be set to NOT NULL
--- So set any NULL values to a reasonable default
+-- It's possible CpuCount could be NULL, and to add it to the
+-- primary key the cloumn has to be set to NOT NULL,
+-- so set any NULL values to a reasonable default.
 UPDATE CloudSummaries SET CpuCount=0 WHERE CpuCount IS NULL;
 
 -- Set CpuCount column to NOT NULL,

--- a/scripts/update-1.6.0-next.sql
+++ b/scripts/update-1.6.0-next.sql
@@ -84,22 +84,26 @@ ALTER TABLE CloudSummaries MODIFY COLUMN UpdateTime TIMESTAMP NOT NULL DEFAULT C
 UPDATE LastUpdated SET UpdateTime = '0000-00-00 00:00:00' WHERE UpdateTime IS NULL;
 ALTER TABLE LastUpdated MODIFY COLUMN UpdateTime TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
 
--- This section will add CpuCount to the CloudSummary
--- primary key. It is grouped on as part of the summariser
--- so should be part of the primary key
+-- This section will add the outstanding fields that are part of the
+-- GROUP BY statement in the summariser to the CloudSummaries
+-- table primary key.
+-- If it is grouped on as part of the summariser,
+-- it should be part of the primary key
 
 -- it's possible CpuCount could be NULL, and to add it to the
 -- primary key the cloumn has to be set to NOT NULL
--- So set any NULL values
+-- So set any NULL values to a reasonable default
 UPDATE CloudSummaries SET CpuCount=0 WHERE CpuCount IS NULL;
 
 -- Set CpuCount column to NOT NULL,
 ALTER TABLE CloudSummaries MODIFY CpuCount INT NOT NULL;
 
--- Add CpuCount to primary key to prevent summaries overriding each other.
-ALTER TABLE CloudSummaries DROP PRIMARY KEY, ADD PRIMARY KEY(SiteID, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId, CpuCount);
-
-
+-- Add fields to primary key to prevent summaries overriding each other.
+ALTER TABLE CloudSummaries DROP PRIMARY KEY, ADD PRIMARY KEY(
+  SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID,
+  VOID, VOGroupID, VORoleID, Status, CloudType, ImageId, CpuCount,
+  BenchmarkType, Benchmark
+  );
 
 */
 

--- a/scripts/update-1.6.0-next.sql
+++ b/scripts/update-1.6.0-next.sql
@@ -70,7 +70,7 @@ ALTER TABLE LastUpdated MODIFY COLUMN UpdateTime TIMESTAMP NOT NULL DEFAULT CURR
 -- upgrade to APEL Version next, remove the block comment
 -- symbols around this section and run this script
 
--- This script will set any null Cloud UpdateTimes to the zero timestamp
+-- This section will set any null Cloud UpdateTimes to the zero timestamp
 -- (to prevent issues determining how recent a record is)
 -- and then explicitly set the UpdateTimes of
 -- future rows to update
@@ -83,6 +83,24 @@ ALTER TABLE CloudSummaries MODIFY COLUMN UpdateTime TIMESTAMP NOT NULL DEFAULT C
 
 UPDATE LastUpdated SET UpdateTime = '0000-00-00 00:00:00' WHERE UpdateTime IS NULL;
 ALTER TABLE LastUpdated MODIFY COLUMN UpdateTime TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+
+-- This section will add CpuCount to the CloudSummary
+-- primary key. It is grouped on as part of the summariser
+-- so should be part of the primary key
+
+-- it's possible CpuCount could be NULL, and to add it to the
+-- primary key the cloumn has to be set to NOT NULL
+-- So set any NULL values
+UPDATE CloudSummaries SET CpuCount=0 WHERE CpuCount IS NULL;
+
+-- Set CpuCount column to NOT NULL,
+ALTER TABLE CloudSummaries MODIFY CpuCount INT NOT NULL;
+
+-- Add CpuCount to primary key to prevent summaries overriding each other.
+ALTER TABLE CloudSummaries DROP PRIMARY KEY, ADD PRIMARY KEY(SiteID, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId, CpuCount);
+
+
+
 */
 
 


### PR DESCRIPTION
For every field in the `GROUP BY` statement in the cloud summariser, it is possible two summaries could only differ by that field. If that field is not part of the primary key, one of those summaries would override the other.

This PR avoids this by adding all fields in the `GROUP BY` statement to the CloudSummaries table primary key.

It also provides an update script to upgrade existing installations.