### PR TITLE
Extra SLURM statuses

### DIFF
--- a/apel/parsers/slurm.py
+++ b/apel/parsers/slurm.py
@@ -98,9 +98,7 @@ class SlurmParser(Parser):
         # Input checking
         if rc['CpuDuration'] < 0:
             raise ValueError('Negative CpuDuration value')
-
-        if rc['WallDuration'] < 0:
-            raise ValueError('Negative WallDuration value')
+        # No negative WallDuration test as parse_time prevents that.
 
         if rc['StopTime'] < rc['StartTime']:
             raise ValueError('StopTime less than StartTime')

--- a/apel/parsers/slurm.py
+++ b/apel/parsers/slurm.py
@@ -59,7 +59,7 @@ class SlurmParser(Parser):
         values = line.strip().split('|')
 
         if values[14] not in ('CANCELLED', 'COMPLETED', 'FAILED',
-                              'PREEMPTED', 'TIMEOUT'):
+                              'NODE_FAIL', 'PREEMPTED', 'TIMEOUT'):
             return None
 
         rmem = self._normalise_memory(values[12])

--- a/apel/parsers/slurm.py
+++ b/apel/parsers/slurm.py
@@ -58,7 +58,8 @@ class SlurmParser(Parser):
         # log.info('line: %s' % (line));
         values = line.strip().split('|')
 
-        if values[14] != 'COMPLETED':
+        if values[14] not in ('CANCELLED', 'COMPLETED', 'FAILED',
+                              'PREEMPTED', 'TIMEOUT'):
             return None
 
         rmem = self._normalise_memory(values[12])

--- a/apel/parsers/slurm.py
+++ b/apel/parsers/slurm.py
@@ -58,6 +58,7 @@ class SlurmParser(Parser):
         # log.info('line: %s' % (line));
         values = line.strip().split('|')
 
+        # These statuses indicate the job has stopped and resources were used.
         if values[14] not in ('CANCELLED', 'COMPLETED', 'FAILED',
                               'NODE_FAIL', 'PREEMPTED', 'TIMEOUT'):
             return None

--- a/test/test_slurm.py
+++ b/test/test_slurm.py
@@ -95,31 +95,32 @@ class ParserSlurmTest(unittest.TestCase):
             self.assertRaises(ValueError, self.parser.parse, line)
 
     def test_job_status(self):
-        accepted = (
+        accepted = (  # These job statuses are all described as "terminated".
             '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|CANCELLED',
             '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|COMPLETED',
             '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|FAILED',
+            '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|NODE_FAIL',
             '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|PREEMPTED',
             '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|TIMEOUT',
         )
 
-        rejected = (
+        rejected = (  # These jobs would be unstarted or still running.
             '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|BOOT_FAIL',
             '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|CONFIGURING',
             '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|COMPLETING',
-            # It's possible that DEADLINE and NODE_FAIL should be accounted for
             '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|DEADLINE',
-            '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|NODE_FAIL',
             '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|PENDING',
             '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|RUNNING',
             '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|RESIZING',
             '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|SUSPENDED',
         )
         for line in accepted:
-            self.assertNotEqual(self.parser.parse(line), None)
+            self.assertNotEqual(self.parser.parse(line), None,
+                                "Line incorrectly rejected: %s" % line)
 
         for line in rejected:
-            self.assertEqual(self.parser.parse(line), None)
+            self.assertEqual(self.parser.parse(line), None,
+                             "Line incorrectly accepted: %s" % line)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_slurm.py
+++ b/test/test_slurm.py
@@ -94,5 +94,32 @@ class ParserSlurmTest(unittest.TestCase):
         for line in value_fails:
             self.assertRaises(ValueError, self.parser.parse, line)
 
+    def test_job_status(self):
+        accepted = (
+            '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|CANCELLED',
+            '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|COMPLETED',
+            '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|FAILED',
+            '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|PREEMPTED',
+            '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|TIMEOUT',
+        )
+
+        rejected = (
+            '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|BOOT_FAIL',
+            '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|CONFIGURING',
+            '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|COMPLETING',
+            # It's possible that DEADLINE and NODE_FAIL should be accounted for
+            '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|DEADLINE',
+            '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|NODE_FAIL',
+            '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|PENDING',
+            '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|RUNNING',
+            '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|RESIZING',
+            '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|SUSPENDED',
+        )
+        for line in accepted:
+            self.assertNotEqual(self.parser.parse(line), None)
+
+        for line in rejected:
+            self.assertEqual(self.parser.parse(line), None)
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_slurm.py
+++ b/test/test_slurm.py
@@ -95,6 +95,7 @@ class ParserSlurmTest(unittest.TestCase):
             self.assertRaises(ValueError, self.parser.parse, line)
 
     def test_job_status(self):
+        """Check that the right statuses are accepted."""
         accepted = (  # These job statuses are all described as "terminated".
             '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|CANCELLED',
             '123|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn|28K|20K|COMPLETED',

--- a/test/test_slurm.py
+++ b/test/test_slurm.py
@@ -36,7 +36,6 @@ class ParserSlurmTest(unittest.TestCase):
                        '324554.batch|batch|||2013-10-28T04:28:30|2013-10-28T04:28:33|00:00:03|3||1|1|wn65|0|0|COMPLETED',  # Zero memory
                        '324554.batch|batch|||2013-10-28T04:28:30|2013-10-28T04:28:33|00:00:03|3||1|1|wn65|20H|54J|COMPLETED',  # Invalid unit prefix
                        '324554.batch|batch|||2013-10-28T04:28:33|2013-10-28T04:28:30|00:00:03|3||1|1|wn65|28K|80K|COMPLETED',  # StopTime < StartTime
-                       '297720.batch|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|-00:00:16|16||1|1|wn37|3228K|23820K|COMPLETED',  # -ve WallDuration
                        '297720.batch|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|-16||1|1|wn37|3228K|23820K|COMPLETED',)  # -ve CpuDuration
 
         # Examples for correct lines
@@ -45,7 +44,8 @@ class ParserSlurmTest(unittest.TestCase):
             ('278952.batch|batch|||2013-10-23T21:37:24|2013-10-25T00:01:37|1-02:24:13|95053||1|1|wn36|438.50M|1567524K|COMPLETED'),
             ('297720.batch|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn37|3228K|23820K|COMPLETED'),
             ('321439.batch|batch|||2013-10-27T17:09:35|2013-10-28T04:47:20|11:37:45|41865||1|1|wn16|770728K|1.40G|COMPLETED'),
-            ('320816.batch|batch|||2013-10-27T14:56:03|2013-10-28T05:03:50|14:07:47|50867||1|1|wn33|1325232K|2.22G|COMPLETED'),)
+            ('320816.batch|batch|||2013-10-27T14:56:03|2013-10-28T05:03:50|14:07:47|50867||1|1|wn33|1325232K|2.22G|COMPLETED'),
+        )
 
         values = (
             ('1000', 'dteam005', 'dteam', 2, 2,
@@ -67,7 +67,8 @@ class ParserSlurmTest(unittest.TestCase):
             ('320816.batch', None, None, 50867, 50867,
              datetime.utcfromtimestamp(mktime((2013, 10, 27, 14, 56, 3, 0, 1, -1))),
              datetime.utcfromtimestamp(mktime((2013, 10, 28, 5, 3, 50, 0, 1, -1))),
-             None, 1325232, int(2.22*1024*1024), 1, 1))
+             None, 1325232, int(2.22*1024*1024), 1, 1),
+        )
 
         cases = {}
         for line, value in zip(lines, values):


### PR DESCRIPTION
As reported on [GGUS](https://ggus.eu/index.php?mode=ticket_info&ticket_id=126954).

Not enough statuses are being accepted by the SLURM parser, so I've added all the ones that seem to indicate that the job has stopped and resources have been used.

Details on the statuses [here](https://slurm.schedmd.com/sacct.html). It's not the clear what some of them mean (mainly DEADLINE), but it should be a lot better than before.

Tested successfully by reporting user.