### PR TITLE
Fix summariser time CpuCount warnings for cloud accounting

### DIFF
--- a/apel/db/records/cloud.py
+++ b/apel/db/records/cloud.py
@@ -89,7 +89,16 @@ class CloudRecord(Record):
         self._record_content['VORole'] = role
         self._record_content['VOGroup'] = group
         self._record_content['VO'] = vo
-        
+
+        # If the message was missing a CpuCount, assume it used
+        # zero Cpus, to prevent a NULL being written into the column
+        # in the CloudRecords tables.
+        # Doing so would be a problem despite the CloudRecords
+        # table allowing it because the CloudSummaries table
+        # doesn't allow it, creating a problem at summariser time.
+        if self._record_content['CpuCount'] is None:
+            self._record_content['CpuCount'] = 0
+
         # Check the values of StartTime and EndTime
         # self._check_start_end_times()
 

--- a/scripts/update-1.6.1-next_version.sql
+++ b/scripts/update-1.6.1-next_version.sql
@@ -1,0 +1,18 @@
+-- This script contains multiple comment blocks that can update
+-- APEL version 1.6.1 databases of the following types to the next version:
+--  - Cloud Accounting Database
+
+-- UPDATE SCRIPT FOR CLOUD SCHEMA
+
+-- If you have a Cloud Accounting Database and wish to
+-- upgrade to APEL Version next, remove the block comment
+-- symbols around this section and run this script
+
+-- This section will:
+-- - Change records with a NULL CpuCount so that they have a CpuCount of 0,
+--   to prevent problems at summarising time.
+
+UPDATE CloudRecords SET
+    CpuCount=0
+    WHERE CpuCount is NULL;
+

--- a/test/test_cloud_record.py
+++ b/test/test_cloud_record.py
@@ -197,7 +197,7 @@ CloudComputeService: Test Service'''
                          'SuspendDuration': None,
                          'WallDuration': None,
                          'CpuDuration': None,
-                         'CpuCount': None,
+                         'CpuCount': 0,
                          'NetworkType': 'None',
                          'NetworkInbound': None,
                          'NetworkOutbound': None,

--- a/test/test_cloud_record.py
+++ b/test/test_cloud_record.py
@@ -168,10 +168,50 @@ CloudType: OpenNebula
                          'Benchmark': 0.0,
                          'ImageId': '\'scilin6\'',
                          'CloudType': 'OpenNebula'}
+
+        self._msg4 = '''
+BenchmarkType: HEPSPEC06
+Status: completed
+SiteName: Test Site
+MachineName: Test Machine
+ImageId: Test Image ID
+LocalUserId: Test Local User ID
+FQAN: NULL
+LocalGroupId: Test Local Group ID
+VMUUID: Test VM ID
+CloudType: caso/0.3.4 (OpenStack)
+GlobalUserName: Test User
+CloudComputeService: Test Service'''
+
+        self._values4 = {'VMUUID': 'Test VM ID',
+                         'SiteName': 'Test Site',
+                         'CloudComputeService': 'Test Service',
+                         'MachineName': 'Test Machine',
+                         'LocalUserId': 'Test Local User ID',
+                         'LocalGroupId': 'Test Local Group ID',
+                         'GlobalUserName': 'Test User',
+                         'FQAN': 'None',
+                         'Status': 'completed',
+                         'StartTime': None,
+                         'EndTime': None,
+                         'SuspendDuration': None,
+                         'WallDuration': None,
+                         'CpuDuration': None,
+                         'CpuCount': None,
+                         'NetworkType': 'None',
+                         'NetworkInbound': None,
+                         'NetworkOutbound': None,
+                         'Memory': None,
+                         'Disk': None,
+                         'StorageRecordId': 'None',
+                         'ImageId': 'Test Image ID',
+                         'CloudType': 'caso/0.3.4 (OpenStack)'}
+
         self.cases = {}
         self.cases[self._msg1] = self._values1
         self.cases[self._msg2] = self._values2
         self.cases[self._msg3] = self._values3
+        self.cases[self._msg4] = self._values4
 
     def test_load_from_msg_value_check(self):
         """Check for correct values in CloudRecords generated from messages."""

--- a/test/test_mysql.py
+++ b/test/test_mysql.py
@@ -109,11 +109,16 @@ class MysqlTest(unittest.TestCase):
         cloud4_nb = apel.db.records.cloud.CloudRecord()
         cloud4_nb.load_from_msg(CLOUD4_NULL_BENCHMARKS)
 
+        # Test a Cloud V0.4 Record with mising fields
+        cloud4_mf = apel.db.records.cloud.CloudRecord()
+        cloud4_mf.load_from_msg(CLOUD4_MISSING_FIELDS)
+
         items_in = cloud2._record_content.items()
         items_in += cloud4._record_content.items()
         items_in += cloud4_nb._record_content.items()
+        items_in += cloud4_mf._record_content.items()
 
-        record_list = [cloud2, cloud4, cloud4_nb]
+        record_list = [cloud2, cloud4, cloud4_nb, cloud4_mf]
 
         # load_records changes the 'cloud' cloud record as it calls _check_fields
         # which adds placeholders to empty fields
@@ -288,6 +293,25 @@ Benchmark: NULL
 StorageRecordId: NULL
 ImageId: 1
 CloudType: Cloud Technology 2
+'''
+
+# A Cloud V0.4 Record, but missing a lot of fields.
+# We need to check we can load this record as we receive
+# messages with records like this and currently
+# load them.
+CLOUD4_MISSING_FIELDS = '''
+BenchmarkType: HEPSPEC06
+Status: completed
+SiteName: Test Site
+MachineName: Test Machine
+ImageId: Test Image ID
+LocalUserId: Test Local User ID
+FQAN: NULL
+LocalGroupId: Test Local Group ID
+VMUUID: Test VM ID
+CloudType: caso/0.3.4 (OpenStack)
+GlobalUserName: Test User
+CloudComputeService: Test Service
 '''
 
 if __name__ == '__main__':


### PR DESCRIPTION
The warnings are caused by CloudRecords with a NULL CpuCount forming CloudSummaries with a NULL CpuCount, which causes the warning because CpuCount is now part of the CloudSummaries primary key (following a bug fix in 1.6.1).

I have made a change to `cloud.py` to prevent new CloudRecords being loaded with a NULL CpuCount, opting for zero as the replacement, so CloudRecords without a CpuCount are as separate as possible from those that do.

I also added test cases to try and highlight what was changing and to show that everything still seems to work.

# Manual Testing
Tested by loading the below message repeatedly into a Cloud database (10.1.20-MariaDB) on a SL7 VM
```APEL-cloud-message: v0.4
BenchmarkType: HEPSPEC06
Status: completed
SiteName: Test Site
MachineName: Test Machine
ImageId: Test Image ID
LocalUserId: Test Local User ID
FQAN: NULL
LocalGroupId: Test Local Group ID
VMUUID: datetime.now()
CloudType: caso/0.3.4 (OpenStack)
GlobalUserName: Test User
CloudComputeService: Test Service
```

under 1.6.1, when loading that message we pass NULL to CpuCount, rather than relying on implicit type correction that's not supported out of the box in newer mysql/mariadb. **Woo!**

```MariaDB [cloud_dev]> select VMUUID, SiteName, CpuCount from VCloudRecords;
+----------------------------+-----------+----------+
| VMUUID                     | SiteName  | CpuCount |
+----------------------------+-----------+----------+
| 2018-03-22 16:24:01.535679 | Test Site |     NULL |
+----------------------------+-----------+----------+
```

This causes the summariser warnings, because CpuCount is in the primary key and hence NOT NULL in the CloudSummaries table. 

```MariaDB [cloud_dev]> Call SummariseVMs();
Query OK, 1 row affected, 3 warnings (0.02 sec)

MariaDB [cloud_dev]> show warnings;
+---------+------+----------------------------------+
| Level   | Code | Message                          |
+---------+------+----------------------------------+
| Warning | 1048 | Column 'Month' cannot be null    |
| Warning | 1048 | Column 'Year' cannot be null     |
| Warning | 1048 | Column 'CpuCount' cannot be null |
+---------+------+----------------------------------+
```

We get away with it because of the implict type correction of NULL to 0 that's not supported out of the box in newer mysql/mariadb. **Boo!**

```MariaDB [cloud_dev]> select UpdateTime, SiteName, CpuCount from VCloudSummaries;
+---------------------+-----------+----------+
| UpdateTime          | SiteName  | CpuCount |
+---------------------+-----------+----------+
| 2018-03-22 16:25:54 | Test Site |        0 |
+---------------------+-----------+----------+
```

To fix existing data, applying the update script
```git checkout cpu_count_summariser_fix
mysql -u root cloud_dev < scripts/update-1.6.1-next_version.sql
```

```MariaDB [cloud_dev]> select VMUUID, SiteName, CpuCount from VCloudRecords;
+----------------------------+-----------+----------+
| VMUUID                     | SiteName  | CpuCount |
+----------------------------+-----------+----------+
| 2018-03-22 16:24:01.535679 | Test Site |        0 |
+----------------------------+-----------+----------+

MariaDB [cloud_dev]> Call SummariseVMs();
Query OK, 2 rows affected, 2 warnings (0.02 sec)

MariaDB [cloud_dev]> show warnings;
+---------+------+-------------------------------+
| Level   | Code | Message                       |
+---------+------+-------------------------------+
| Warning | 1048 | Column 'Month' cannot be null |
| Warning | 1048 | Column 'Year' cannot be null  |
+---------+------+-------------------------------+
```
and no stale summaries :)

```MariaDB [cloud_dev]> select UpdateTime, SiteName, CpuCount from VCloudSummaries;
+---------------------+-----------+----------+
| UpdateTime          | SiteName  | CpuCount |
+---------------------+-----------+----------+
| 2018-03-22 16:28:03 | Test Site |        0 |
+---------------------+-----------+----------+
```

The changes to the `cloud.py` mean newly loaded records without a CpuCount get a CpuCount of 0.

```MariaDB [cloud_dev]> select VMUUID, SiteName, CpuCount from VCloudRecords;
+----------------------------+-----------+----------+
| VMUUID                     | SiteName  | CpuCount |
+----------------------------+-----------+----------+
| 2018-03-22 16:24:01.535679 | Test Site |        0 |
| 2018-03-22 16:30:20.062425 | Test Site |        0 |
+----------------------------+-----------+----------+
```