### PR TITLE
Remove references to specific LSF versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Python and uses MySQL. It has the following components:
 ### apel-parsers
 
 These extract data from the following batch systems:
-* LSF 5.x to 9.x
+* LSF
 * PBS
 * SGE/OGE
 * SLURM

--- a/apel/parsers/lsf.py
+++ b/apel/parsers/lsf.py
@@ -29,12 +29,7 @@ log = logging.getLogger(__name__)
 
 class LSFParser(Parser):
     '''
-    LSFParser parses LSF accounting logs from versions:
-     - 5.x
-     - 6.x
-     - 7.x
-     - 8.x
-     - 9.x
+    LSFParser parses LSF accounting logs from all LSF versions.
 
     The expression below describes elements which we are looking for.
     Here is some explanation:

--- a/bin/parser.py
+++ b/bin/parser.py
@@ -18,7 +18,7 @@
 # - BLAH
 # - PBS
 # - SGE
-# - LSF (5.x to 9.x)
+# - LSF
 
 '''
     @author: Konrad Jopek, Will Rogers


### PR DESCRIPTION
Remove references to specific LSF versions as that restriction has been
removed from the code a while ago (but the docs weren't updated).