### PR TITLE
Improvements to slurm_acc script

### DIFF
--- a/scripts/slurm_acc.sh
+++ b/scripts/slurm_acc.sh
@@ -5,4 +5,4 @@
 NOW=$(date +"%Y%m%d")
 FILE="/var/log/apel/slurm_acc.$NOW"
 
-/usr/local/bin/sacct -P -n --format=JobID,JobName,User,Group,Start,End,Elapsed,CPUTimeRAW,Partition,NCPUS,NNodes,NodeList,MaxRSS,MaxVMSize,State -j "$JOBID" >> "$FILE"
+sacct -P -n --format=JobID,JobName,User,Group,Start,End,Elapsed,CPUTimeRAW,Partition,NCPUS,NNodes,NodeList,MaxRSS,MaxVMSize,State -j "$JOBID" >> "$FILE"

--- a/scripts/slurm_acc.sh
+++ b/scripts/slurm_acc.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
-/bin/sleep 2
+sleep 2
 
 NOW=$(date +"%Y%m%d")
 FILE="/var/log/apel/slurm_acc.$NOW"

--- a/scripts/slurm_acc.sh
+++ b/scripts/slurm_acc.sh
@@ -5,5 +5,4 @@
 NOW=$(date +"%Y%m%d")
 FILE="/var/log/apel/slurm_acc.$NOW"
 
-/usr/local/bin/sacct -P -n --format=JobID,JobName,User,Group,Start,End,Elapsed,CPUTimeRAW,Partition,NCPUS,NNodes,NodeList,MaxRSS,MaxVMSize,State -j $JOBID >> $FILE
-
+/usr/local/bin/sacct -P -n --format=JobID,JobName,User,Group,Start,End,Elapsed,CPUTimeRAW,Partition,NCPUS,NNodes,NodeList,MaxRSS,MaxVMSize,State -j "$JOBID" >> "$FILE"


### PR DESCRIPTION
Resolves #12. With thanks to @jrha.

- Tidy up slurm_acc using shellcheck suggestions (quoting variables).
- Change sacct call to remove path - this will remove problems of diff install locations, and should be safe as this script takes no arguments and is run by cron.
- Change slurm_acc to use bash and sleep to builtin.