### PR TITLE
Add support for different CPU time fields for SLURM

### DIFF
--- a/apel/common/datetime_utils.py
+++ b/apel/common/datetime_utils.py
@@ -12,7 +12,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
    @author Konrad Jopek, Will Rogers
 '''
 
@@ -25,7 +25,7 @@ def valid_from(date, days=1):
     '''
     Method for BlahParser
     Returns calculated value for ValidFrom field.
-    
+
     By default it returns Timestamp - 1 day
     '''
     delta = datetime.timedelta(days=days)
@@ -36,7 +36,7 @@ def valid_until(date, days=28):
     '''
     Method for BlahParser
     Returns calculated value for ValidUntil field.
-    
+
     By default it returns Timestamp + 28 days
     '''
     delta = datetime.timedelta(days=days)
@@ -47,9 +47,9 @@ def parse_timestamp(datetime_string):
     '''
     Parse timestamp encoded as a string in various forms.  Return
     a TZ-unaware datetime object, which is in UTC.
-    
+
     If timezone information is not present in the string, it
-    assumes that the timezone is UTC.  
+    assumes that the timezone is UTC.
     '''
     dt = iso8601.parse_date(datetime_string)
     utcdt = dt.astimezone(iso8601.iso8601.UTC)

--- a/apel/common/datetime_utils.py
+++ b/apel/common/datetime_utils.py
@@ -58,14 +58,19 @@ def parse_timestamp(datetime_string):
 
 
 def parse_time(timestring):
-    '''
-    Return seconds from times of the form d-h:m:s or h:m:s.
-    '''
+    """Return integer seconds from times of form d-h:m:s, h:m:s or m:s.s."""
     if '-' in timestring:
         days, sub_days = timestring.split('-')
     else:
         days, sub_days = 0, timestring
-    hours, minutes, seconds = sub_days.split(':')
+
+    if '.' in sub_days:
+        hours = 0
+        minutes, decimal_s = sub_days.split(':')
+        seconds = int(round(float(decimal_s)))
+    else:
+        hours, minutes, seconds = sub_days.split(':')
+
     return 86400*int(days) + 3600*int(hours) + 60*int(minutes) + int(seconds)
 
 

--- a/scripts/slurm_acc.sh
+++ b/scripts/slurm_acc.sh
@@ -1,8 +1,23 @@
 #!/bin/bash
 
+# This script can be run to extract usage accounting data from SLURM for later
+# parsing by an APEL client. There is a choice of sacct commands to run below.
+
+
 sleep 2
 
 NOW=$(date +"%Y%m%d")
 FILE="/var/log/apel/slurm_acc.$NOW"
 
+
+# Please comment/uncomment the approriate sacct lines for your use case.
+
+# This is the original sacct call which uses CPUTimeRAW for CPU Duration.
+# CPUTimeRAW is equal to Elapsed and so gives unrealistic efficiency.
+
 sacct -P -n --format=JobID,JobName,User,Group,Start,End,Elapsed,CPUTimeRAW,Partition,NCPUS,NNodes,NodeList,MaxRSS,MaxVMSize,State -j "$JOBID" >> "$FILE"
+
+# This sacct call uses TotalCPU for CPU Duration which is the sum of SystemCPU and UserCPU.
+# TotalCPU should give more realistic efficiency but may not work well for multicore jobs.
+
+### sacct -P -n --format=JobID,JobName,User,Group,Start,End,Elapsed,TotalCPU,Partition,NCPUS,NNodes,NodeList,MaxRSS,MaxVMSize,State -j "$JOBID" >> "$FILE"

--- a/test/test_slurm.py
+++ b/test/test_slurm.py
@@ -45,6 +45,20 @@ class ParserSlurmTest(unittest.TestCase):
             ('297720.batch|batch|||2013-10-25T12:11:20|2013-10-25T12:11:36|00:00:16|16||1|1|wn37|3228K|23820K|COMPLETED'),
             ('321439.batch|batch|||2013-10-27T17:09:35|2013-10-28T04:47:20|11:37:45|41865||1|1|wn16|770728K|1.40G|COMPLETED'),
             ('320816.batch|batch|||2013-10-27T14:56:03|2013-10-28T05:03:50|14:07:47|50867||1|1|wn33|1325232K|2.22G|COMPLETED'),
+            # These lines use TotalCPU rather than CPUTimeRAW which uses a
+            # different time format to the integer seconds of CPUTimeRAW.
+            # d-h:m:s format:
+            ('5940815|cream_877733810|user1|group1|2018-06-03T02:11:12|'
+             '2018-06-05T03:36:08|2-01:24:56|8-15:40:36|partition|8|1|'
+             'wn1|||COMPLETED'),
+            # h:m:s format:
+            ('5961074|cream_538395496|user2|group2|2018-06-05T13:30:17|'
+             '2018-06-05T14:40:05|01:09:48|01:09:18|partition|1|1|wn2|'
+             '||COMPLETED'),
+            # m:s.s format:
+            ('5979785|cream_636487219|user3|group3|2018-06-05T14:59:34|'
+             '2018-06-05T15:02:59|00:03:25|01:05.753|partition|1|1|wn3|'
+             '||COMPLETED'),
         )
 
         values = (
@@ -68,6 +82,18 @@ class ParserSlurmTest(unittest.TestCase):
              datetime.utcfromtimestamp(mktime((2013, 10, 27, 14, 56, 3, 0, 1, -1))),
              datetime.utcfromtimestamp(mktime((2013, 10, 28, 5, 3, 50, 0, 1, -1))),
              None, 1325232, int(2.22*1024*1024), 1, 1),
+            ('5940815', 'user1', 'group1', ((2*24+1)*60+24)*60+56, ((8*24+15)*60+40)*60+36,
+             datetime.utcfromtimestamp(mktime((2018, 6, 3, 2, 11, 12, 0, 1, -1))),
+             datetime.utcfromtimestamp(mktime((2018, 6, 5, 3, 36, 8, 0, 1, -1))),
+             'partition', None, None, 1, 8),
+            ('5961074', 'user2', 'group2', (1*60+9)*60+48, (1*60+9)*60+18,
+             datetime.utcfromtimestamp(mktime((2018, 6, 5, 13, 30, 17, 0, 1, -1))),
+             datetime.utcfromtimestamp(mktime((2018, 6, 5, 14, 40, 5, 0, 1, -1))),
+             'partition', None, None, 1, 1),
+            ('5979785', 'user3', 'group3', 3*60+25, 1*60+6,
+             datetime.utcfromtimestamp(mktime((2018, 6, 5, 14, 59, 34, 0, 1, -1))),
+             datetime.utcfromtimestamp(mktime((2018, 6, 5, 15, 2, 59, 0, 1, -1))),
+             'partition', None, None, 1, 1),
         )
 
         cases = {}
@@ -123,6 +149,7 @@ class ParserSlurmTest(unittest.TestCase):
         for line in rejected:
             self.assertEqual(self.parser.parse(line), None,
                              "Line incorrectly accepted: %s" % line)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Resolves #160.

This PR adds support for different time formats of CPU duration to be passed to the SLURM parser. This is to allow for the use of either `CPUTimeRAW` or `TotalCPU` from `sacct` which each have good and bad points depending on use case. I have decided not to enforce either format as the new field TotalCPU may not be so good for multicore jobs. **I've left it up to the user as to which they use.**

I've also added the different CPU time options to the `slurm_acc.sh` script, added unit tests, and tidied some whitespace.