### PR TITLE
Build tidy

### DIFF
--- a/apel.spec
+++ b/apel.spec
@@ -34,7 +34,7 @@ apel-lib provides required libraries for the rest of APEL system.
 %package parsers
 Summary:        Parsers for APEL system
 Group:          Development/Languages
-Requires:       apel-lib >= 1.7.0
+Requires:       apel-lib >= %{version}
 Requires(pre):  shadow-utils
 
 %description parsers
@@ -44,7 +44,7 @@ supported by the APEL system: Torque, SGE and LSF.
 %package client
 Summary:        APEL client package
 Group:          Development/Languages
-Requires:       apel-lib >= 1.7.0, apel-ssm
+Requires:       apel-lib >= %{version}, apel-ssm
 Requires(pre):  shadow-utils
 
 %description client
@@ -55,7 +55,7 @@ SSM.
 %package server
 Summary:        APEL server package
 Group:          Development/Languages
-Requires:       apel-lib >= 1.7.0, apel-ssm
+Requires:       apel-lib >= %{version}, apel-ssm
 Requires(pre):  shadow-utils
 
 %description server

--- a/scripts/apel-build-rpm
+++ b/scripts/apel-build-rpm
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-# Execute the following as root to install build tools and create a build user:
+# Execute the following as root to install build tools and create a build user
+# (to allow copying as non-root add the option "-K UMASK=0022" to useradd):
+
 # yum install fedora-packager
 # useradd -m rpmb
 # usermod -a -G mock rpmb
 
-# Then swtich to the rpmb user (su - rpmb) and run this file, altering version.
+# Then swtich to the rpmb user (su - rpmb) and run this file, altering VERSION.
 
 rpmdev-setuptree
 


### PR DESCRIPTION
This PR has the following changes:

- Add comment in build script about using UMASK to allow the finished RPMs to be copied out by a non-root user. (e.g. on SCD Cloud VMs.)
- Capitalise VERSION in build script comment to match variable name.
- Replace repeated version numbers in SPEC file with equivalent tag so that we don't have to remember to update them regularly.