### PR TITLE
Split test requirements out and add constraint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,9 @@ cache: pip
 # Avoid pip log from affecting cache
 before_cache: rm -fv ~/.cache/pip/log/debug.log
 
-# Install defaults to "pip install -r requirements.txt"
+install:
+  - pip install -r requirements.txt
+  - pip install -r requirements-test.txt
 
 # Commands that prepare things for the test
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,12 @@ cache: pip
 before_cache: rm -fv ~/.cache/pip/log/debug.log
 
 install:
-  # Base requirements
+  # Base requirements for apel
   - pip install -r requirements.txt
   # Additional requirements for the unit and coverage tests
   - pip install -r requirements-test.txt
 
-# Commands that prepare things for the test
+# Commands to prepare environment for the test
 before_script:
   - export PYTHONPATH=$PYTHONPATH:`pwd -P`
   - cd test

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ cache: pip
 before_cache: rm -fv ~/.cache/pip/log/debug.log
 
 install:
+  # Base requirements
   - pip install -r requirements.txt
+  # Additional requirements for the unit and coverage tests
   - pip install -r requirements-test.txt
 
 # Commands that prepare things for the test

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,4 @@
 # Constraints that apply to requirements-test.txt
+
 # coveralls dependency that needs an older version for Python 2.6
 pycparser<2.19

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,4 @@
-# Constraints that apply to requirements-test.txt
+# Constraints that apply to pip installed requirements
 
 # coveralls dependency that needs an older version for Python 2.6
 pycparser<2.19

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,3 @@
+# Constraints that apply to requirements-test.txt
+# coveralls dependency that needs an older version for Python 2.6
+pycparser<2.19

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,6 @@
+# Constraints on requirements below
+-c constraints.txt
+# Requirements for testing
+unittest2
+coveralls
+mock

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
-# Constraints on requirements below
+# Constraints on the requirements below
 -c constraints.txt
-# Requirements for testing
+# Additional requirements for running unit and coverage tests
 unittest2
 coveralls
 mock

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,8 @@
+# Additional requirements for the unit and coverage tests
+
 # Constraints on the requirements below
 -c constraints.txt
-# Additional requirements for running unit and coverage tests
+
 unittest2
 coveralls
 mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+# Base requirements for apel
+
 MySQL-python
 python-ldap
 iso8601

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,3 @@ MySQL-python
 python-ldap
 iso8601
 dirq
-# Dependencies for testing
-unittest2
-coveralls
-mock


### PR DESCRIPTION
As per apel/ssm#81.

- Move test requirements into separate requirements file to make it
clearer that they are only needed for running unit tests.
- Add constraints file called from the test requirements file to limit
one of coveralls' dependencies to an earlier version that works with
Python 2.6.