### PR TITLE
Use wildcard glob matching to ensure setup.py installs any update scripts under scripts, to match apel.spec 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ Requires setuptools.
 """
 
 import glob
-from os import remove, path
+from os import remove
 from shutil import copyfile
 import sys
 

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,8 @@ def main():
                       (log_rotate_dir, log_rotate_files),
                       # Create empty directories
                       ('/var/log/apel', []),
-                      ('/var/run/apel', [])],
+                      ('/var/run/apel', [])
+                      ],
           # zip_safe allows setuptools to install the project
           # as a zipfile, for maximum performance!
           # We have disabled this feature so installing via the setup

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ Usage: 'python setup.py install'
 Requires setuptools.
 """
 
+import glob
 from os import remove, path
 from shutil import copyfile
 import sys
@@ -50,7 +51,9 @@ def main():
                     'schemas/cloud.sql',
                     'schemas/storage.sql']
 
-    update_scripts = ['scripts/update_schema.sql']
+    # Wildcarding for update scripts (like we do in the spec file)
+    # prevents having to manually update this variable.
+    update_scripts = glob.glob('scripts/update-*.sql')
 
     accounting_files = ['scripts/slurm_acc.sh', 'scripts/htcondor_acc.sh']
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ Usage: 'python setup.py install'
 Requires setuptools.
 """
 
-from os import remove, path, makedirs
+from os import remove, path
 from shutil import copyfile
 import sys
 
@@ -30,12 +30,6 @@ def main():
         copyfile('bin/dbunloader.py', 'bin/apeldbunloader')
         copyfile('bin/summariser.py', 'bin/apelsummariser')
         copyfile('bin/retrieve_dns.py', 'bin/apelauth')
-
-        if not path.exists('/var/log/apel'):
-            makedirs('/var/log/apel')
-
-        if not path.exists('/var/run/apel'):
-            makedirs('/var/run/apel')
 
     # conf_files will later be copied to conf_dir
     conf_dir = '/etc/apel/'
@@ -94,7 +88,10 @@ def main():
                       (data_dir, accounting_files),
                       (data_dir, message_files),
                       (data_dir, update_scripts),
-                      (log_rotate_dir, log_rotate_files)],
+                      (log_rotate_dir, log_rotate_files),
+                      # Create empty directories
+                      ('/var/log/apel', []),
+                      ('/var/run/apel', [])],
           # zip_safe allows setuptools to install the project
           # as a zipfile, for maximum performance!
           # We have disabled this feature so installing via the setup

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ def main():
                       (log_rotate_dir, log_rotate_files),
                       # Create empty directories
                       ('/var/log/apel', []),
-                      ('/var/run/apel', [])
+                      ('/var/run/apel', []),
                       ],
           # zip_safe allows setuptools to install the project
           # as a zipfile, for maximum performance!


### PR DESCRIPTION
Resolves #165 

This prevents having to manually update the list of update scripts so long as the current naming convention continues.

I also took this opportunity to move the directory creation (`/var/log/apel` and `/var/run/apel`) into the `setup` call, rather than as hacky `if` statements.