### PR TITLE
Clarify what local_jobs and send_ur options do in unloader config

### DIFF
--- a/conf/unloader.cfg
+++ b/conf/unloader.cfg
@@ -13,8 +13,12 @@ dir_location=/var/spool/apel/
 # VStarRecords
 table_name = VJobRecords
 
-# Only for job records and summaries
+# Only used when sending job records, job summaries or storage records.
+# - for grid accounting, if send_ur is true, records and summaries will be sent
+#   in the OGF Usage Record format.
+# - for storage accounting, send_ur must be true.
 send_ur = false
+# Only for job records and summaries, to report on local jobs at the site.
 local_jobs = true
 
 withhold_dns = false


### PR DESCRIPTION
specifically, clarify that `send_ur` is also used for storage accounting. As someone setting up a regional APEL server for storage accounting might not know that `send_ur` has to be true to unload storage records.