### PR TITLE
New, optional, cputmult factor 

### DIFF
--- a/apel/parsers/htcondor.py
+++ b/apel/parsers/htcondor.py
@@ -43,7 +43,7 @@ class HTCondorParser(Parser):
 
         values = line.strip().split('|')
         cputmult = float(1.0)
-        if (len(values) > 10):
+        if len(values) > 10:
             cputmult = float(values[10])
 
         mapping = {'Site'            : lambda x: self.site_name,

--- a/apel/parsers/htcondor.py
+++ b/apel/parsers/htcondor.py
@@ -53,7 +53,7 @@ class HTCondorParser(Parser):
                    'LocalUserID'     : lambda x: x[1],
                    'LocalUserGroup'  : lambda x: "",
                    'WallDuration'    : lambda x: int(x[2]) * cputmult,
-                   'CpuDuration'     : lambda x: ((int(x[3])+int(x[4])) 
+                   'CpuDuration'     : lambda x: ((int(x[3])+int(x[4]))
                                                   * cputmult),
                    'StartTime'       : lambda x: x[5],
                    'StopTime'        : lambda x: x[6],

--- a/apel/parsers/htcondor.py
+++ b/apel/parsers/htcondor.py
@@ -42,6 +42,8 @@ class HTCondorParser(Parser):
         # arcce.rl.ac.uk#2376.0#71589|tatls011|287|107|11|1435671643|1435671930|26636|26832|1|1
 
         values = line.strip().split('|')
+
+        # Set scaling factor using value from log if appended to log line.
         cputmult = float(1.0)
         if len(values) > 10:
             cputmult = float(values[10])
@@ -53,8 +55,8 @@ class HTCondorParser(Parser):
                    'LocalUserID'     : lambda x: x[1],
                    'LocalUserGroup'  : lambda x: "",
                    'WallDuration'    : lambda x: int(x[2]) * cputmult,
-                   'CpuDuration'     : lambda x: ((int(x[3])+int(x[4]))
-                                                  * cputmult),
+                   'CpuDuration'     : lambda x: (int(x[3]) + int(x[4]))
+                                                 * cputmult,
                    'StartTime'       : lambda x: x[5],
                    'StopTime'        : lambda x: x[6],
                    'MemoryReal'      : lambda x: int(x[7]),

--- a/apel/parsers/htcondor.py
+++ b/apel/parsers/htcondor.py
@@ -70,7 +70,4 @@ class HTCondorParser(Parser):
 
         record = EventRecord()
         record.set_all(rc)
-
-        cont = record._record_content
-
         return record

--- a/apel/parsers/htcondor.py
+++ b/apel/parsers/htcondor.py
@@ -42,6 +42,9 @@ class HTCondorParser(Parser):
         # arcce.rl.ac.uk#2376.0#71589|tatls011|287|107|11|1435671643|1435671930|26636|26832|1|1
 
         values = line.strip().split('|')
+        cputmult = float(1.0)
+        if (len(values) > 10):
+            cputmult = float(values[10])
 
         mapping = {'Site'            : lambda x: self.site_name,
                    'MachineName'     : lambda x: self.machine_name,
@@ -49,8 +52,9 @@ class HTCondorParser(Parser):
                    'JobName'         : lambda x: x[0],
                    'LocalUserID'     : lambda x: x[1],
                    'LocalUserGroup'  : lambda x: "",
-                   'WallDuration'    : lambda x: int(x[2]),
-                   'CpuDuration'     : lambda x: int(x[3])+int(x[4]),
+                   'WallDuration'    : lambda x: int(x[2]) * cputmult,
+                   'CpuDuration'     : lambda x: ((int(x[3])+int(x[4])) 
+                                                  * cputmult),
                    'StartTime'       : lambda x: x[5],
                    'StopTime'        : lambda x: x[6],
                    'MemoryReal'      : lambda x: int(x[7]),
@@ -66,4 +70,7 @@ class HTCondorParser(Parser):
 
         record = EventRecord()
         record.set_all(rc)
+
+        cont = record._record_content
+
         return record

--- a/test/test_htcondor_parser.py
+++ b/test/test_htcondor_parser.py
@@ -13,10 +13,7 @@ class HTCondorParserTest(unittest.TestCase):
         self.parser = HTCondorParser('testSite', 'testHost', True)
 
     def test_parse_line_no_cputmult(self):
-        """
-        In this case, the input records contain either 1 for their cputmult factor, or it is missing altogether.
-        Note: the extra field [10] is an error in the original test, but it serves me well here.
-        """
+        """Check parsing of original 10 item long log line."""
 
         keys = ('JobName', 'LocalUserID', 'LocalUserGroup', 'WallDuration',
                 'CpuDuration', 'StartTime', 'StopTime', 'MemoryReal',
@@ -75,10 +72,7 @@ class HTCondorParserTest(unittest.TestCase):
                                  (cont[key], cases[line][key], key))
 
     def test_parse_line_with_cputmult(self):
-        """
-        In this case, the input records contain 1.5 for their cputmult factor.
-        The expected result fields (values) have been timesed up to check the factor is applied.
-        """
+        """Check parsing of 11 item line (scaling factor of 1.5 appended)."""
 
         keys = ('JobName', 'LocalUserID', 'LocalUserGroup', 'WallDuration',
                 'CpuDuration', 'StartTime', 'StopTime', 'MemoryReal',
@@ -91,26 +85,26 @@ class HTCondorParserTest(unittest.TestCase):
 
         # Examples for correct lines
         lines = (
-            '1234567|opssgm|19|18|8|1412688273|1412708199|712944|2075028|1|1.5',
-            'arcce.rl.ac.uk#2376.0#1589|tatls011|287|107|12|1435671643|1435671930|26636|26832|1|1.5',
-            'arcce.rl.ac.uk#2486.0#1888|t2k016|4|0|0|1435671919|1435671922|0|11|1|1.5',
-            'arcce.rl.ac.uk#2478.0#1874|snoplus014|2|0|0|1435671918|1435671920|0|11|1|1.5',
+            '1234567|opsgm|19|18|8|1412688273|1412708199|712944|2075028|1|1.5',
+            'ce.ac.uk#7|l011|287|107|12|1435671643|1435671930|6636|6832|1|1.5',
+            'ce.ac.uk#2486.0|t2k016|4|0|0|1435671919|1435671922|0|11|1|1.5',
+            'ce.ac.uk#278.0|snoplus014|2|0|0|1435671918|1435671920|0|11|1|1.5',
         )
 
         values = (
-            ('1234567', 'opssgm', None, 28, 39,
+            ('1234567', 'opsgm', None, 28, 39,
              datetime.datetime(2014, 10, 7, 13, 24, 33),
              datetime.datetime(2014, 10, 7, 18, 56, 39),
              712944, 2075028, 0, 1),
-            ('arcce.rl.ac.uk#2376.0#1589', 'tatls011', None, 430, 178,
+            ('ce.ac.uk#7', 'l011', None, 430, 178,
              datetime.datetime(2015, 6, 30, 13, 40, 43),
              datetime.datetime(2015, 6, 30, 13, 45, 30),
-             26636, 26832, 0, 1),
-            ('arcce.rl.ac.uk#2486.0#1888', 't2k016', None, 6, 0,
+             6636, 6832, 0, 1),
+            ('ce.ac.uk#2486.0', 't2k016', None, 6, 0,
              datetime.datetime(2015, 6, 30, 13, 45, 19),
              datetime.datetime(2015, 6, 30, 13, 45, 22),
              0, 11, 0, 1),
-            ('arcce.rl.ac.uk#2478.0#1874', 'snoplus014', None, 3, 0,
+            ('ce.ac.uk#278.0', 'snoplus014', None, 3, 0,
              datetime.datetime(2015, 6, 30, 13, 45, 18),
              datetime.datetime(2015, 6, 30, 13, 45, 20),
              0, 11, 0, 1),

--- a/test/test_htcondor_parser.py
+++ b/test/test_htcondor_parser.py
@@ -92,7 +92,7 @@ class HTCondorParserTest(unittest.TestCase):
         # Examples for correct lines
         lines = (
             '1234567|opssgm|19|18|8|1412688273|1412708199|712944|2075028|1|1.5',
-            'arcce.rl.ac.uk#2376.0#1589|tatls011|287|107|11|1435671643|1435671930|26636|26832|1|1.5',
+            'arcce.rl.ac.uk#2376.0#1589|tatls011|287|107|12|1435671643|1435671930|26636|26832|1|1.5',
             'arcce.rl.ac.uk#2486.0#1888|t2k016|4|0|0|1435671919|1435671922|0|11|1|1.5',
             'arcce.rl.ac.uk#2478.0#1874|snoplus014|2|0|0|1435671918|1435671920|0|11|1|1.5',
         )
@@ -102,7 +102,7 @@ class HTCondorParserTest(unittest.TestCase):
              datetime.datetime(2014, 10, 7, 13, 24, 33),
              datetime.datetime(2014, 10, 7, 18, 56, 39),
              712944, 2075028, 0, 1),
-            ('arcce.rl.ac.uk#2376.0#1589', 'tatls011', None, 430, 177,
+            ('arcce.rl.ac.uk#2376.0#1589', 'tatls011', None, 430, 178,
              datetime.datetime(2015, 6, 30, 13, 40, 43),
              datetime.datetime(2015, 6, 30, 13, 45, 30),
              26636, 26832, 0, 1),

--- a/test/test_htcondor_parser.py
+++ b/test/test_htcondor_parser.py
@@ -12,7 +12,11 @@ class HTCondorParserTest(unittest.TestCase):
     def setUp(self):
         self.parser = HTCondorParser('testSite', 'testHost', True)
 
-    def test_parse_line(self):
+    def test_parse_line_no_cputmult(self):
+        """
+        In this case, the input records contain either 1 for their cputmult factor, or it is missing altogether.
+        Note: the extra field [10] is an error in the original test, but it serves me well here.
+        """
 
         keys = ('JobName', 'LocalUserID', 'LocalUserGroup', 'WallDuration',
                 'CpuDuration', 'StartTime', 'StopTime', 'MemoryReal',
@@ -45,6 +49,68 @@ class HTCondorParserTest(unittest.TestCase):
              datetime.datetime(2015, 6, 30, 13, 45, 22),
              0, 11, 0, 1),
             ('arcce.rl.ac.uk#2478.0#1874', 'snoplus014', None, 2, 0,
+             datetime.datetime(2015, 6, 30, 13, 45, 18),
+             datetime.datetime(2015, 6, 30, 13, 45, 20),
+             0, 11, 0, 1),
+        )
+
+        cases = {}
+        for line, value in zip(lines, values):
+            cases[line] = dict(zip(keys, value))
+
+        for line in cases.keys():
+            record = self.parser.parse(line)
+            cont = record._record_content
+
+            self.assertEqual(cont['Site'], 'testSite')
+            self.assertEqual(cont['MachineName'], 'testHost')
+            self.assertEqual(cont['Infrastructure'], 'APEL-CREAM-HTCONDOR')
+
+            for key in cases[line].keys():
+                self.assertTrue(key in cont, "Key '%s' not in record." % key)
+
+            for key in cases[line].keys():
+                self.assertEqual(cont[key], cases[line][key],
+                                 "%s != %s for key %s." %
+                                 (cont[key], cases[line][key], key))
+
+    def test_parse_line_with_cputmult(self):
+        """
+        In this case, the input records contain 1.5 for their cputmult factor.
+        The expected result fields (values) have been timesed up to check the factor is applied.
+        """
+
+        keys = ('JobName', 'LocalUserID', 'LocalUserGroup', 'WallDuration',
+                'CpuDuration', 'StartTime', 'StopTime', 'MemoryReal',
+                'MemoryVirtual', 'NodeCount', 'Processors')
+
+        # condor_history output (line split):
+        #   GlobalJobId|Owner|RemoteWallClockTime|RemoteUserCpu|RemoteSysCpu|
+        #   JobStartDate|EnteredCurrentStatus|ResidentSetSize_RAW|ImageSize_RAW|
+        #   RequestCpus
+
+        # Examples for correct lines
+        lines = (
+            '1234567|opssgm|19|18|8|1412688273|1412708199|712944|2075028|1|1.5',
+            'arcce.rl.ac.uk#2376.0#1589|tatls011|287|107|11|1435671643|1435671930|26636|26832|1|1.5',
+            'arcce.rl.ac.uk#2486.0#1888|t2k016|4|0|0|1435671919|1435671922|0|11|1|1.5',
+            'arcce.rl.ac.uk#2478.0#1874|snoplus014|2|0|0|1435671918|1435671920|0|11|1|1.5',
+        )
+
+        values = (
+            ('1234567', 'opssgm', None, 28, 39,
+             datetime.datetime(2014, 10, 7, 13, 24, 33),
+             datetime.datetime(2014, 10, 7, 18, 56, 39),
+             712944, 2075028, 0, 1),
+            ('arcce.rl.ac.uk#2376.0#1589', 'tatls011', None, 430, 177,
+             datetime.datetime(2015, 6, 30, 13, 40, 43),
+             datetime.datetime(2015, 6, 30, 13, 45, 30),
+             26636, 26832, 0, 1),
+            ('arcce.rl.ac.uk#2486.0#1888', 't2k016', None, 6, 0,
+             datetime.datetime(2015, 6, 30, 13, 45, 19),
+             datetime.datetime(2015, 6, 30, 13, 45, 22),
+             0, 11, 0, 1),
+            ('arcce.rl.ac.uk#2478.0#1874', 'snoplus014', None, 3, 0,
              datetime.datetime(2015, 6, 30, 13, 45, 18),
              datetime.datetime(2015, 6, 30, 13, 45, 20),
              0, 11, 0, 1),


### PR DESCRIPTION
The new, optional, cputmult factor will, if present in the accounting line, apply a
scaling factor to wall and cpu durations. If not present, the scaling factor defaults to 1.0, i.e. no
change. This will allow apelclient to be used in htcondorce deployments.
The unit test for htcondor.py has been expanded to include a run
with this feature. Existing sites who use (say) CREAM/HTCondor (who would not
include this new field) will be unaffected. The scheme described here:

https://twiki.cern.ch/twiki/bin/view/LCG/HTCondorAccounting