### PR TITLE
Add warnings in log if no records unloaded

### DIFF
--- a/bin/client.py
+++ b/bin/client.py
@@ -272,7 +272,10 @@ def run_client(ccp):
                 log.warn('Unrecognised interval: %s', interval)
                 log.warn('Will not start unloader.')
 
-            log.info('Unloaded %d records in %d messages.', recs, msgs)
+            if recs > 0:
+                log.info('Unloaded %d records in %d messages.', recs, msgs)
+            else:
+                log.warning('No records unloaded. Please check your config.')
 
         except KeyError:
             log.warn('Invalid table name: %s, omitting', table_name)
@@ -282,7 +285,10 @@ def run_client(ccp):
         # Always send sync messages
         msgs, recs = unloader.unload_sync()
 
-        log.info('Unloaded %d sync records in %d messages.', recs, msgs)
+        if recs > 0:
+            log.info('Unloaded %d sync records in %d messages.', recs, msgs)
+        else:
+            log.warning('No sync records unloaded. Please check your config.')
 
         log.info('Unloading complete.')
         log.info(LOG_BREAK)


### PR DESCRIPTION
We often get people raising tickets when they realise their accounting data isn't displaying and it turns out to be a publishing issue. Sometimes they've not checked their log, and other times they just haven't spotted any problems in the log.

This PR addresses the second case by adding warnings in log if no usage or sync records are unloaded to hopefully make it clearer when something has not gone right.