### PR TITLE
Add manual_spec option to update the SpecLevels without any BDII.

### DIFF
--- a/bin/client.py
+++ b/bin/client.py
@@ -206,9 +206,9 @@ def run_client(ccp):
         log.info(LOG_BREAK)
         sys.exit(1)
 
-    log.info('Manual spec updater.')
+    log.info('Running manual spec update.')
     specs = []
-    index = 0
+    index = 1
     while True:
         key = 'manual_spec' + str(index)
         try:
@@ -218,7 +218,7 @@ def run_client(ccp):
         specs.append(spec)
         index += 1
 
-    if index > 0:
+    if len(specs) > 0:
         try:
             s = ccp.get('spec_updater', 'site_name')
         except ConfigParser.NoOptionError:
@@ -238,6 +238,7 @@ def run_client(ccp):
             ce = parts[0]
             slt = parts[1]
             db.update_spec(s, ce, slt, sl)
+    log.info('Manual spec update finished. %s updated.', len(specs))
 
     if spec_updater_enabled:
         log.info(LOG_BREAK)

--- a/bin/client.py
+++ b/bin/client.py
@@ -209,29 +209,31 @@ def run_client(ccp):
     log.info('Manual spec updater.')
     specs = []
     index = 0
-    while (True):
+    while True:
         key = 'manual_spec' + str(index)
         try:
             spec = ccp.get('spec_updater', key)
         except ConfigParser.NoOptionError:
             break
         specs.append(spec)
-        index = index + 1
+        index += 1
 
-    if (index > 0):
+    if index > 0:
         try:
             s = ccp.get('spec_updater', 'site_name')
         except ConfigParser.NoOptionError:
-            log.error('Site name must be configured for manual_spec definitions.')
+            log.error('Site name must be configured '
+                      'for manual_spec definitions.')
             sys.exit(1)
         for spec in specs:
             parts = spec.split(',')
-            if (len(parts) != 3 ):
+            if len(parts) != 3:
                 log.warn('Check manual_spec definitions.')
             try:
                 sl = float(parts[2])
             except ValueError:
-                log.error('Service level must be a number for manual_spec definitions.')
+                log.error('Service level must be a number '
+                          'for manual_spec definitions.')
                 sys.exit(1)
             ce = parts[0]
             slt = parts[1]

--- a/bin/client.py
+++ b/bin/client.py
@@ -206,6 +206,37 @@ def run_client(ccp):
         log.info(LOG_BREAK)
         sys.exit(1)
 
+    log.info('Manual spec updater.')
+    specs = []
+    index = 0
+    while (True):
+        key = 'manual_spec' + str(index)
+        try:
+            spec = ccp.get('spec_updater', key)
+        except ConfigParser.NoOptionError:
+            break
+        specs.append(spec)
+        index = index + 1
+
+    if (index > 0):
+        try:
+            s = ccp.get('spec_updater', 'site_name')
+        except ConfigParser.NoOptionError:
+            log.error('Site name must be configured for manual_spec definitions.')
+            sys.exit(1)
+        for spec in specs:
+            parts = spec.split(',')
+            if (len(parts) != 3 ):
+                log.warn('Check manual_spec definitions.')
+            try:
+                sl = float(parts[2])
+            except ValueError:
+                log.error('Service level must be a number for manual_spec definitions.')
+                sys.exit(1)
+            ce = parts[0]
+            slt = parts[1]
+            db.update_spec(s, ce, slt, sl)
+
     if spec_updater_enabled:
         log.info(LOG_BREAK)
         log.info('Starting spec updater.')

--- a/conf/client.cfg
+++ b/conf/client.cfg
@@ -25,6 +25,14 @@ ldap_port = 2170
 #spec_type = HEPSPEC
 #spec_value = 1.0
 
+## To manually set specs for all jobs (not just local ones), configure lines
+## like the following named "manual_spec" followed by consecutive integers for
+## however many batch systems are relevant. The value should be a unique name
+## for the system, then the spec type ('HEPSPEC' or 'Si2k') and the spec value.
+# manual_spec1 = grid10.uni.ac.uk:1234/grid10.uni.ac.uk-condor,HEPSPEC,10.0
+# manual_spec2 = grid22.uni.ac.uk:1234/grid22.uni.ac.uk-condor,HEPSPEC,15.0
+# manual_spec3 = grid35.uni.ac.uk:1234/grid35.uni.ac.uk-condor,HEPSPEC,15.0
+
 [joiner]
 enabled = true
 local_jobs = false


### PR DESCRIPTION
Add manual_spec option to update the SpecLevels without any BDII. The code pulls out all config lines like these:
[spec_updater]
......
manual_spec0 = hepgrid6.ph.liv.ac.uk:9619/hepgrid6.ph.liv.ac.uk-condor,HEPSPEC,10.0
manual_spec1 = hepgrid24.ph.liv.ac.uk:9619/hepgrid6.ph.liv.ac.uk-condor,HEPSPEC,15.0

If lines are found, it checks that the site_name is configured, then verifies the data and uses db.update_spec to push them into the apel db SpecRecords table. This does all the work in one section of 30 lines of code. It changes no other parts of the system - all existing features are left exactly as they stand.
