### PR TITLE
Add Measurement variables to cloud record ignored fields

### DIFF
--- a/apel/db/records/cloud.py
+++ b/apel/db/records/cloud.py
@@ -50,7 +50,10 @@ class CloudRecord(Record):
         self._db_fields = self._msg_fields[:9] + ['VO', 'VOGroup', 'VORole'] + self._msg_fields[9:]
         self._all_fields = self._db_fields
         
-        self._ignored_fields = ["UpdateTime"]
+        self._ignored_fields = [
+            "UpdateTime", "MeasurementTime", "MeasurementMonth",
+            "MeasurementYear",
+        ]
         
         # Fields which will have an integer stored in them
         self._int_fields = [ "SuspendDuration", "WallDuration", "CpuDuration", "CpuCount", 

--- a/apel/db/records/cloud.py
+++ b/apel/db/records/cloud.py
@@ -50,10 +50,8 @@ class CloudRecord(Record):
         self._db_fields = self._msg_fields[:9] + ['VO', 'VOGroup', 'VORole'] + self._msg_fields[9:]
         self._all_fields = self._db_fields
         
-        self._ignored_fields = [
-            "UpdateTime", "MeasurementTime", "MeasurementMonth",
-            "MeasurementYear",
-        ]
+        self._ignored_fields = ["UpdateTime", "MeasurementTime",
+                                "MeasurementMonth", "MeasurementYear"]
         
         # Fields which will have an integer stored in them
         self._int_fields = [ "SuspendDuration", "WallDuration", "CpuDuration", "CpuCount", 


### PR DESCRIPTION
Resolves #193 

As discussed in that issue, treat `Measurement{Time, Month, Year}` the same as `UpdateTime`, as they are all created in the database on load but we dont necessarily want them being unloaded.