### PR TITLE
pycodestyle: Only warn about lines longer than 120 characters

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pycodestyle]
+max-line-length = 120


### PR DESCRIPTION
pycodestyle was formerly pep8 and is what code climate uses.