### PR TITLE
GT-149 Add support for deleting stale cloud summaries reporting recent usage.

### DIFF
--- a/apel/db/backends/mysql.py
+++ b/apel/db/backends/mysql.py
@@ -422,7 +422,7 @@ class ApelMysqlDb(object):
             # - Are older than the start time of this summariser run (i.e. are
             #   stale)
             # AND
-            # - Are reporting recent usage as defined by the threhsold value
+            # - Are reporting recent usage as defined by the threshold value
             delete_statement = (
                 "DELETE FROM CloudSummaries WHERE "
                 "Month>=%s AND "

--- a/apel/db/backends/mysql.py
+++ b/apel/db/backends/mysql.py
@@ -443,8 +443,8 @@ class ApelMysqlDb(object):
 
             log.info("Removed %s stale summaries." % number_deleted)
 
-        except MySQLdb.Error, error:
-            log.error("A mysql error occurred: %s", error)
+        except MySQLdb.Error as e:
+            log.error("A mysql error occurred: %s", e)
             log.error("Any transaction will be rolled back.")
 
             if self.db is not None:

--- a/apel/db/backends/mysql.py
+++ b/apel/db/backends/mysql.py
@@ -435,13 +435,13 @@ class ApelMysqlDb(object):
             )
 
             log.info(
-                "Running \"%s\" to delete stale summaries" % delete_statement
+                "Running \"%s\" to delete stale summaries", delete_statement
             )
             number_deleted = cursor.execute(delete_statement)
 
             self.db.commit()
 
-            log.info("Removed %s stale summaries." % number_deleted)
+            log.info("Removed %s stale summaries.", number_deleted)
 
         except MySQLdb.Error as e:
             log.error("A mysql error occurred: %s", e)

--- a/apel/db/backends/mysql.py
+++ b/apel/db/backends/mysql.py
@@ -425,9 +425,9 @@ class ApelMysqlDb(object):
             # - Are reporting recent usage as defined by the threshold value
             delete_statement = (
                 "DELETE FROM CloudSummaries WHERE "
-                "Month>=%s AND "
-                "Year>=%s AND "
-                "UpdateTime<'%s';"
+                "Month >= %s AND "
+                "Year >= %s AND "
+                "UpdateTime < '%s';"
                 % (
                     threshold_month, threshold_year,
                     summariser_start_time.strftime("%Y-%m-%d %H:%M:%S")

--- a/apel/db/backends/mysql.py
+++ b/apel/db/backends/mysql.py
@@ -405,15 +405,7 @@ class ApelMysqlDb(object):
                 self.db.rollback()
             raise
 
-    def clean_stale_summaries(self, db_type, summariser_start_time, threshold):
-        """For the DB type, remove stale summaries newer than the threshold."""
-        if db_type == "cloud":
-            self._clean_stale_cloud_summaries(summariser_start_time, threshold)
-        else:
-            raise ValueError("Attempting to clean up summaries in a %s db, "
-                             "this is not supported." % db_type)
-
-    def _clean_stale_cloud_summaries(self, summariser_start_time, threshold):
+    def clean_stale_cloud_summaries(self, summariser_start_time, threshold):
         """Remove stale cloud summaries newer than the threshold."""
         threshold_timedelta = datetime.timedelta(days=threshold)
         threshold_time = summariser_start_time - threshold_timedelta

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -25,6 +25,7 @@ standard_library.install_aliases()
 from future.builtins import str
 
 from optparse import OptionParser
+import datetime
 import logging.config
 import os
 import sys
@@ -89,6 +90,9 @@ def runprocess(db_config_file, config_file, log_config_file):
         sys.exit(1)
 
     log.info('Starting apel summariser version %s.%s.%s', *__version__)
+    # Keep track of when this summariser run started to possibly identify
+    # stale summaries later.
+    summariser_start_time = datetime.datetime.now()
 
     # If the pidfile exists, don't start up.
     try:

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -134,8 +134,8 @@ def runprocess(db_config_file, config_file, log_config_file):
         stale_summary_clean_up = False
 
         try:
-            stale_summary_newer_than = cp.getint('summariser',
-                                                 'stale_summary_window_days')
+            stale_summary_window_days = cp.getint('summariser',
+                                                  'stale_summary_window_days')
 
         except (ConfigParser.Error, ValueError) as error:
             log.warning("Could not configure stale summary clean up.")
@@ -162,7 +162,7 @@ def runprocess(db_config_file, config_file, log_config_file):
             # Optionally clean up any newly stale cloud summariy records.
             if stale_summary_clean_up:
                 db.clean_stale_cloud_summaries(summariser_start_time,
-                                               stale_summary_newer_than)
+                                               stale_summary_window_days)
 
         else:
             raise ApelDbException('Unknown database type: %s' % db_type)

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -119,28 +119,12 @@ def runprocess(db_config_file, config_file, log_config_file):
         stale_summary_clean_up = cp.getboolean('summariser',
                                                'delete_stale_summaries')
 
-    except ConfigParser.NoSectionError as error:
-        # If section no defined, assume the user has made no effort to
-        # configure stale summary clean up, in which case - just log the
-        # exception as info.
-        log.info("Will not clean up stale summarises.")
-        stale_summary_clean_up = False
+        stale_summary_window_days = cp.getint('summariser',
+                                              'stale_summary_window_days')
 
     except ConfigParser.NoOptionError as error:
-        # If the section is defined and the option is not, assume the user has
-        # made effort to configure stale summary clean up, in which case - log
-        # the exception it as a warning.
-        log.warning("Will not clean up stale summarises.")
+        log.debug("No settings defined to clean up stale summaries.")
         stale_summary_clean_up = False
-
-        try:
-            stale_summary_window_days = cp.getint('summariser',
-                                                  'stale_summary_window_days')
-
-        except (ConfigParser.Error, ValueError) as error:
-            log.warning("Could not configure stale summary clean up.")
-            log.warning("Will not clean up stale summaries.")
-            stale_summary_clean_up = False
 
     # Log into the database
     try:

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -164,6 +164,11 @@ def runprocess(db_config_file, config_file, log_config_file):
             db.copy_summaries()
         elif db_type == 'cloud':
             db.summarise_cloud()
+            # Optionally clean up any newly stale cloud summariy records.
+            if stale_summary_clean_up:
+                db.clean_stale_cloud_summaries(summariser_start_time,
+                                               stale_summary_newer_than)
+
         else:
             raise ApelDbException('Unknown database type: %s' % db_type)
 
@@ -171,10 +176,7 @@ def runprocess(db_config_file, config_file, log_config_file):
         elapsed_time = round(time.time() - start_time, 3)
         log.info('Summarising completed in: %s seconds', elapsed_time)
 
-        if stale_summary_clean_up:
-            log.info("Cleaning up stale summaries")
-            db.clean_stale_summaries(db_type, summariser_start_time,
-                                     stale_summary_newer_than)
+
 
         log.info(LOG_BREAK)
 

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -130,7 +130,7 @@ def runprocess(db_config_file, config_file, log_config_file):
         # If the section is defined and the option is not, assume the user has
         # made effort to configure stale summary clean up, in which case - log
         # the exception it as a warning.
-        log.warn("Will not clean up stale summarises.")
+        log.warning("Will not clean up stale summarises.")
         stale_summary_clean_up = False
 
     if stale_summary_clean_up:
@@ -143,8 +143,8 @@ def runprocess(db_config_file, config_file, log_config_file):
                                                  'newer_than')
 
         except (ConfigParser.Error, ValueError) as error:
-            log.warn("Could not configure stale summary clean up.")
-            log.warn("Will not clean up stale summaries.")
+            log.warning("Could not configure stale summary clean up.")
+            log.warning("Will not clean up stale summaries.")
             stale_summary_clean_up = False
 
     # Log into the database

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -141,7 +141,7 @@ def runprocess(db_config_file, config_file, log_config_file):
             db.copy_summaries()
         elif db_type == 'cloud':
             db.summarise_cloud()
-            # Optionally clean up any newly stale cloud summariy records.
+            # Optionally clean up any newly stale cloud summary records.
             if stale_summary_clean_up:
                 db.clean_stale_cloud_summaries(start_time,
                                                stale_summary_window_days)

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -122,6 +122,7 @@ def runprocess(db_config_file, config_file, log_config_file):
     except ConfigParser.NoOptionError as _error:
         log.debug("No settings defined to clean up stale summaries.")
         stale_summary_clean_up = False
+        stale_summary_window_days = None
 
     # Log into the database
     try:

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -116,8 +116,8 @@ def runprocess(db_config_file, config_file, log_config_file):
 
     # Configure options for stale summary clean up.
     try:
-        stale_summary_clean_up = cp.getboolean('stale_summaries',
-                                               'enable_clean_up')
+        stale_summary_clean_up = cp.getboolean('summariser',
+                                               'delete_stale_summaries')
 
     except ConfigParser.NoSectionError as error:
         # If section no defined, assume the user has made no effort to
@@ -139,8 +139,8 @@ def runprocess(db_config_file, config_file, log_config_file):
             sys.exit(1)
 
         try:
-            stale_summary_newer_than = cp.getint('stale_summaries',
-                                                 'newer_than')
+            stale_summary_newer_than = cp.getint('summariser',
+                                                 'stale_summary_window_days')
 
         except (ConfigParser.Error, ValueError) as error:
             log.warning("Could not configure stale summary clean up.")

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -133,11 +133,6 @@ def runprocess(db_config_file, config_file, log_config_file):
         log.warning("Will not clean up stale summarises.")
         stale_summary_clean_up = False
 
-    if stale_summary_clean_up:
-        if db_type != "cloud":
-            log.error("Can only enable summary clean up for Cloud accounting.")
-            sys.exit(1)
-
         try:
             stale_summary_newer_than = cp.getint('summariser',
                                                  'stale_summary_window_days')

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -116,13 +116,13 @@ def runprocess(db_config_file, config_file, log_config_file):
         stale_summary_clean_up = cp.getboolean('summariser',
                                                'delete_stale_summaries')
 
-        stale_summary_window_days = cp.getint('summariser',
-                                              'stale_summary_window_days')
+        stale_summary_age_limit_days = cp.getint('summariser',
+                                                 'stale_summary_window_days')
 
     except ConfigParser.NoOptionError as _error:
         log.debug("No settings defined to clean up stale summaries.")
         stale_summary_clean_up = False
-        stale_summary_window_days = None
+        stale_summary_age_limit_days = None
 
     # Log into the database
     try:
@@ -144,7 +144,7 @@ def runprocess(db_config_file, config_file, log_config_file):
             # Optionally clean up any newly stale cloud summary records.
             if stale_summary_clean_up:
                 db.clean_stale_cloud_summaries(start_time,
-                                               stale_summary_window_days)
+                                               stale_summary_age_limit_days)
 
         else:
             raise ApelDbException('Unknown database type: %s' % db_type)

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -122,7 +122,7 @@ def runprocess(db_config_file, config_file, log_config_file):
         stale_summary_window_days = cp.getint('summariser',
                                               'stale_summary_window_days')
 
-    except ConfigParser.NoOptionError as error:
+    except ConfigParser.NoOptionError as _error:
         log.debug("No settings defined to clean up stale summaries.")
         stale_summary_clean_up = False
 

--- a/conf/summariser.cfg
+++ b/conf/summariser.cfg
@@ -1,23 +1,20 @@
 [summariser]
 # Location of the pidfile
 pidfile = /var/run/apel/summariser.pid
-
-# Define if and how the summariser should handle stale summaries.
-[stale_summaries]
-# If enable_clean_up equals true, stale summaries in the database will
+# If delete_stale_summaries equals true, stale summaries in the database will
 # be deleted.
-enable_clean_up = true
-# Use newer_than to limit the deletion of stale summaries to those
+delete_stale_summaries = true
+# Use stale_summary_window_days to limit the deletion of stale summaries to those
 # reporting recent usage. This avoids deleting stale summaries that
 # may be produced by deleting individual records regularly as part an
 # implementation of a long term retention policy.
-# The recommended setting is that newer_than should be set to twice the time
+# The recommended setting is that stale_summary_window_days should be set to twice the time
 # between individual summariser runs to ensure the month boundary is handled
 # correctly.
 # i.e. 2 days if you summarise daily.
-# The unit of newer_than is days, though the cut off used will be rounded down
+# The unit of stale_summary_window_days is days, though the cut off used will be rounded down
 # to the start of the calendar month.
-newer_than = 2
+stale_summary_window_days = 2
 
 [logging]
 logfile = /var/log/apel/summariser.log

--- a/conf/summariser.cfg
+++ b/conf/summariser.cfg
@@ -6,3 +6,20 @@ pidfile = /var/run/apel/summariser.pid
 logfile = /var/log/apel/summariser.log
 level = INFO
 console = true
+
+# Define if and how the summariser should handle stale summaries.
+[stale_summaries]
+# If enable_clean_up equals true, stale summaries in the database will
+# be deleted.
+enable_clean_up = true
+# Use newer_than to limit the deletion of stale summaries to those
+# reporting recent usage. This avoids deleting stale summaries that
+# may be produced by deleting individual records regularly as part an
+# implementation of a long term retention policy.
+# The recommended setting is that newer_than should be set to twice the time
+# between individual summariser runs to ensure the month boundary is handled
+# correctly.
+# i.e. 2 days if you summarise daily.
+# The unit of newer_than is days, though the cut off used will be rounded down
+# to the start of the calendar month.
+newer_than = 2

--- a/conf/summariser.cfg
+++ b/conf/summariser.cfg
@@ -3,7 +3,7 @@
 pidfile = /var/run/apel/summariser.pid
 
 # If delete_stale_summaries equals true, stale summaries in the database will
-# be deleted.
+# be deleted. ***This currently only works for Cloud Summaries.***
 delete_stale_summaries = true
 
 # Use stale_summary_window_days to limit the deletion of stale summaries to

--- a/conf/summariser.cfg
+++ b/conf/summariser.cfg
@@ -6,7 +6,7 @@ pidfile = /var/run/apel/summariser.pid
 delete_stale_summaries = true
 # Use stale_summary_window_days to limit the deletion of stale summaries to those
 # reporting recent usage. This avoids deleting stale summaries that
-# may be produced by deleting individual records regularly as part an
+# may be produced by deleting individual records regularly as part of an
 # implementation of a long term retention policy.
 # The recommended setting is that stale_summary_window_days should be set to twice the time
 # between individual summariser runs to ensure the month boundary is handled

--- a/conf/summariser.cfg
+++ b/conf/summariser.cfg
@@ -2,11 +2,6 @@
 # Location of the pidfile
 pidfile = /var/run/apel/summariser.pid
 
-[logging]
-logfile = /var/log/apel/summariser.log
-level = INFO
-console = true
-
 # Define if and how the summariser should handle stale summaries.
 [stale_summaries]
 # If enable_clean_up equals true, stale summaries in the database will
@@ -23,3 +18,8 @@ enable_clean_up = true
 # The unit of newer_than is days, though the cut off used will be rounded down
 # to the start of the calendar month.
 newer_than = 2
+
+[logging]
+logfile = /var/log/apel/summariser.log
+level = INFO
+console = true

--- a/conf/summariser.cfg
+++ b/conf/summariser.cfg
@@ -1,19 +1,22 @@
 [summariser]
 # Location of the pidfile
 pidfile = /var/run/apel/summariser.pid
+
 # If delete_stale_summaries equals true, stale summaries in the database will
 # be deleted.
 delete_stale_summaries = true
-# Use stale_summary_window_days to limit the deletion of stale summaries to those
-# reporting recent usage. This avoids deleting stale summaries that
-# may be produced by deleting individual records regularly as part of an
+
+# Use stale_summary_window_days to limit the deletion of stale summaries to
+# those reporting recent usage. This avoids deleting stale summaries that may
+# be produced by deleting individual records regularly as part of an
 # implementation of a long term retention policy.
-# The recommended setting is that stale_summary_window_days should be set to twice the time
-# between individual summariser runs to ensure the month boundary is handled
-# correctly.
-# i.e. 2 days if you summarise daily.
-# The unit of stale_summary_window_days is days, though the cut off used will be rounded down
-# to the start of the calendar month.
+#
+# The recommended setting is that stale_summary_window_days should be set to
+# twice the time between individual summariser runs to ensure the month
+# boundary is handled correctly. i.e. 2 days if you summarise daily.
+#
+# The unit of stale_summary_window_days is days, though the cut off used will
+# be rounded down to the start of the calendar month.
 stale_summary_window_days = 2
 
 [logging]


### PR DESCRIPTION
To help with [this GUS ticket](https://ggus.eu/index.php?mode=ticket_info&ticket_id=147103).

Resolves #217 by adding the option `enable_clean_up` to the `summariser.cfg` which, if `true` will trigger logic to delete stale cloud summaries reporting recent usage after the summariser has run. It also adds the option `newer_than` to allow a configurable definition of "recent", in terms of days.

**Manual testing**
with `enable_clean_up = true` and `newer_than = 2`

Lets say we have an old summary that is stale because we deleted the corresponding records as part of a retention policy.
```
MariaDB [217_test]> REPLACE INTO CloudSummaries (UpdateTime, SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId, CpuCount, BenchmarkType, Benchmark, WallDuration) VALUES ("2020-01-04 00:00:05", 1, 1, 1, 2020, 1, 1, 1, 1, "completed", "A Cloud", 1, 1, "FOO", 1, 4000);

MariaDB [217_test]> select UpdateTime, SiteID, CloudComputeServiceID, GlobalUserNameID, Month, Year, Status, WallDuration from CloudSummaries;
+---------------------+--------+-----------------------+------------------+-------+------+-----------+--------------+
| UpdateTime          | SiteID | CloudComputeServiceID | GlobalUserNameID | Month | Year | Status    | WallDuration |
+---------------------+--------+-----------------------+------------------+-------+------+-----------+--------------+
| 2020-01-04 00:00:05 |      1 |                     1 |                1 |     1 | 2020 | completed |         NULL |
+---------------------+--------+-----------------------+------------------+-------+------+-----------+--------------+
1 row in set (0.001 sec)
```

At some point in the future, we receive a record for a running VM.
```
MariaDB [217_test]> REPLACE INTO CloudRecords (RecordCreateTime, MeasurementTime, VMUUID, SiteID, CloudComputeServiceID, GlobalUserNameID, MeasurementMonth, MeasurementYear, Status, WallDuration, VOID, VOGroupID, VORoleID, BenchmarkType, Benchmark, PublisherDNID, CloudType, ImageId, CpuCount, StartTime) VALUES('2020-10-08 09:55', '2020-10-08 09:55', 1, 1, 1, 1, 10, 2020, "started", 100, 1, 1, 1, "FOO", 1, 1, "A Cloud", 1, 1, "2020-10-08 08:55");
```

At some point that record gets summarised.
```
[user@host-172-16-113-91 apel]$ python bin/summariser.py -c conf/summariser.cfg -d conf/db.cfg
2020-10-08 10:26:08,883 - summariser - INFO - Starting apel summariser version 1.8.2
2020-10-08 10:26:08,884 - summariser - INFO - Created Pidfile
2020-10-08 10:26:08,884 - summariser - INFO - Connecting to the database ...
2020-10-08 10:26:08,895 - summariser - INFO - Connected.
2020-10-08 10:26:08,896 - apel.db.backends.mysql - INFO - Summarising cloud records...
2020-10-08 10:26:08,898 - apel.db.backends.mysql - INFO - Done.
2020-10-08 10:26:08,908 - summariser - INFO - Summarising complete.
2020-10-08 10:26:08,908 - summariser - INFO - Cleaning up stale summaries
2020-10-08 10:26:08,909 - apel.db.backends.mysql - INFO - Removed 0 stale summaries.
2020-10-08 10:26:08,909 - summariser - INFO - ========================================
2020-10-08 10:26:08,909 - summariser - INFO - Removing Pidfile
2020-10-08 10:26:08,909 - summariser - INFO - ========================================
```

The summaries table looks as expected.
```
MariaDB [217_test]> select UpdateTime, SiteID, CloudComputeServiceID, GlobalUserNameID, Month, Year, Status, WallDuration from CloudSummaries;
+---------------------+--------+-----------------------+------------------+-------+------+-----------+--------------+
| UpdateTime          | SiteID | CloudComputeServiceID | GlobalUserNameID | Month | Year | Status    | WallDuration |
+---------------------+--------+-----------------------+------------------+-------+------+-----------+--------------+
| 2020-01-04 00:00:05 |      1 |                     1 |                1 |     1 | 2020 | completed |         4000 |
| 2020-10-08 10:26:08 |      1 |                     1 |                1 |    10 | 2020 | started   |          100 |
+---------------------+--------+-----------------------+------------------+-------+------+-----------+--------------+
2 rows in set (0.001 sec)
```

Then we receive a "completed" record for that VM. The "completed" record correctly overrides the "started" record.

```
MariaDB [217_test]> REPLACE INTO CloudRecords (RecordCreateTime, MeasurementTime, VMUUID, SiteID, CloudComputeServiceID, GlobalUserNameID, MeasurementMonth, MeasurementYear, Status, WallDuration, VOID, VOGroupID, VORoleID, BenchmarkType, Benchmark, PublisherDNID, CloudType, ImageId, CpuCount, StartTime, EndTime) VALUES('2020-10-08 10:01', '2020-10-08 10:01', 1, 1, 1, 1, 10, 2020, "completed", 200, 1, 1, 1, "FOO", 1, 1, "A Cloud", 1, 1, "2020-10-08 08:55", "2020-10-08 10:01");

MariaDB [217_test]> SELECT VMUUID, SiteID, CloudComputeServiceID, GlobalUserNameID, MeasurementMonth, MeasurementYear, Status, WallDuration FROM CloudRecords;
+--------+--------+-----------------------+------------------+------------------+-----------------+-----------+--------------+
| VMUUID | SiteID | CloudComputeServiceID | GlobalUserNameID | MeasurementMonth | MeasurementYear | Status    | WallDuration |
+--------+--------+-----------------------+------------------+------------------+-----------------+-----------+--------------+
| 1      |      1 |                     1 |                1 |               10 |            2020 | completed |          200 |
+--------+--------+-----------------------+------------------+------------------+-----------------+-----------+--------------+
```

At some point, we summarise again.
```
[user@host-172-16-113-91 apel]$ python bin/summariser.py -c conf/summariser.cfg -d conf/db.cfg
2020-10-08 10:28:42,222 - summariser - INFO - Starting apel summariser version 1.8.2
2020-10-08 10:28:42,223 - summariser - INFO - Created Pidfile
2020-10-08 10:28:42,223 - summariser - INFO - Connecting to the database ...
2020-10-08 10:28:42,234 - summariser - INFO - Connected.
2020-10-08 10:28:42,234 - apel.db.backends.mysql - INFO - Summarising cloud records...
2020-10-08 10:28:42,236 - apel.db.backends.mysql - INFO - Done.
2020-10-08 10:28:42,241 - summariser - INFO - Summarising complete.
2020-10-08 10:28:42,241 - summariser - INFO - Cleaning up stale summaries
2020-10-08 10:28:42,249 - apel.db.backends.mysql - INFO - Removed 1 stale summaries.
2020-10-08 10:28:42,249 - summariser - INFO - ========================================
2020-10-08 10:28:42,249 - summariser - INFO - Removing Pidfile
2020-10-08 10:28:42,249 - summariser - INFO - ========================================
```

A stale summary was created, but it was cleaned up straight away.

The older stale summary remains, as desired.

```
MariaDB [217_test]> select UpdateTime, SiteID, CloudComputeServiceID, GlobalUserNameID, Month, Year, Status, WallDuration from CloudSummaries;
+---------------------+--------+-----------------------+------------------+-------+------+-----------+--------------+
| UpdateTime          | SiteID | CloudComputeServiceID | GlobalUserNameID | Month | Year | Status    | WallDuration |
+---------------------+--------+-----------------------+------------------+-------+------+-----------+--------------+
| 2020-01-04 00:00:05 |      1 |                     1 |                1 |     1 | 2020 | completed |         4000 |
| 2020-10-08 10:28:42 |      1 |                     1 |                1 |    10 | 2020 | completed |          200 |
+---------------------+--------+-----------------------+------------------+-------+------+-----------+--------------+
```