### PR TITLE
Add support for loading IP Accounting Messages/Records into a DB

### DIFF
--- a/apel/common/__init__.py
+++ b/apel/common/__init__.py
@@ -18,7 +18,7 @@
 
 from datetime_utils import valid_from,valid_until, parse_timestamp, parse_time, iso2seconds
 from exceptions import install_exc_handler, default_handler
-from parsing_utils import parse_fqan
+from parsing_utils import parse_fqan_db_safe, parse_fqan
 from hashing import calculate_hash
 
 import logging

--- a/apel/common/message_schemas.py
+++ b/apel/common/message_schemas.py
@@ -1,0 +1,149 @@
+"""A file to store message schemas for JSON based messages"""
+
+IP_MSG_SCHEMA = {
+    "definitions": {
+
+    },
+    "$schema": "http: //json-schema.org/draft-07/schema#",
+    "$id": "http: //example.com/root.json",
+    "type": "object",
+    "title": "The Root Schema",
+    "required": [],
+    "properties": {
+        "Type": {
+            "$id": "#/properties/Type",
+            "type": "string",
+            "title": "The Type Schema",
+            "const": "APEL Public IP message"
+        },
+        "Version": {
+            "$id": "#/properties/Version",
+            "type": "string",
+            "title": "The Version Schema",
+            "enum": [
+                "v0.2"
+            ],
+
+        },
+        "UsageRecords": {
+            "$id": "#/properties/UsageRecords",
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1000,
+            "title": "The UsageRecords Schema",
+            "items": {
+                "$id": "#/properties/UsageRecords/items",
+                "type": "object",
+                "title": "The UsageRecord Schema",
+                "required": [
+                    "MeasurementTime",
+                    "SiteName",
+                    "CloudType",
+                    "LocalUser",
+                    "LocalGroup",
+                    "GlobalUserName",
+                    "FQAN",
+                    "IPVersion",
+                    "IPCount"
+                ],
+                "properties": {
+                    "MeasurementTime": {
+                        "$id": "#/properties/UsageRecords/items/properties/MeasurementTime",
+                        "type": "integer",
+                        "title": "The MeasurementTime Schema",
+                        "examples": [
+                            1536070129
+                        ]
+                    },
+                    "SiteName": {
+                        "$id": "#/properties/UsageRecords/items/properties/SiteName",
+                        "type": "string",
+                        "title": "The SiteName Schema",
+                        "examples": [
+                            "TEST-SITE"
+                        ],
+
+                    },
+                    "CloudComputeService": {
+                        "$id": "#/properties/UsageRecords/items/properties/CloudComputeService",
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "title": "The CloudComputeService Schema",
+                        "examples": [
+                            "TEST-CLOUD"
+                        ],
+
+                    },
+                    "CloudType": {
+                        "$id": "#/properties/UsageRecords/items/properties/CloudType",
+                        "type": "string",
+                        "title": "The CloudType Schema",
+                        "examples": [
+                            "caso/1.1.0  (OpenStack)",
+                            "OpenNebula oneacct-export/0.4.6"
+                        ],
+
+                    },
+                    "LocalUser": {
+                        "$id": "#/properties/UsageRecords/items/properties/LocalUser",
+                        "type": "string",
+                        "title": "The LocalUser Schema",
+                        "examples": [
+                            "User1"
+                        ],
+
+                    },
+                    "LocalGroup": {
+                        "$id": "#/properties/UsageRecords/items/properties/LocalGroup",
+                        "type": "string",
+                        "title": "The LocalGroup Schema",
+                        "examples": [
+                            "Group1"
+                        ],
+
+                    },
+                    "GlobalUserName": {
+                        "$id": "#/properties/UsageRecords/items/properties/GlobalUserName",
+                        "type": "string",
+                        "title": "The GlobalUserName Schema",
+                        "examples": [
+                            "GlobalUser1"
+                        ],
+
+                    },
+                    "FQAN": {
+                        "$id": "#/properties/UsageRecords/items/properties/FQAN",
+                        "type": "string",
+                        "title": "The FQAN Schema",
+                        "examples": [
+                            "None",
+                            "alice",
+                            "/fedcloud.egi.eu/Role=NULL/Capability=NULL"
+                        ],
+
+                    },
+                    "IPVersion": {
+                        "$id": "#/properties/UsageRecords/items/properties/IPVersion",
+                        "type": "integer",
+                        "enum": [
+                            4,
+                            6
+                        ],
+                        "title": "The IPVersion Schema"
+                    },
+                    "IPCount": {
+                        "$id": "#/properties/UsageRecords/items/properties/IPCount",
+                        "type": "integer",
+                        "minimum": 0,
+                        "title": "The IPCount Schema",
+                        "examples": [
+                            12
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/apel/common/parsing_utils.py
+++ b/apel/common/parsing_utils.py
@@ -57,3 +57,23 @@ def parse_fqan(fqan):
     except Exception:
         log.warn("FQAN in non-standard format: " + fqan)
         return (None, None, fqan)
+
+def parse_fqan_db_safe(fqan):
+    """
+    Extract three pieces of information from a FQAN: role, group and VO.
+
+    We can't / don't put NULL(/None) in the database,
+    so this method replaces those with the more DB friendly 'None'.
+    """
+    # Extract the relevant information from the user fqan.
+    # Keep the fqan itself as other methods in the class use it.
+    role, group, vo = parse_fqan(fqan)
+    # We can't / don't put NULL in the database, so we use 'None'
+    if role is None:
+        role = 'None'
+    if group is None:
+        group = 'None'
+    if vo is None:
+        vo = 'None'
+
+    return role, group, vo

--- a/apel/db/__init__.py
+++ b/apel/db/__init__.py
@@ -21,5 +21,6 @@ NORMALISED_SUMMARY_MSG_HEADER = "APEL-summary-job-message: v0.3"
 SYNC_MSG_HEADER = "APEL-sync-message: v0.1"
 CLOUD_MSG_HEADER = 'APEL-cloud-message: v0.4'
 CLOUD_SUMMARY_MSG_HEADER = 'APEL-cloud-summary-message: v0.4'
+IP_MSG_TYPE = "APEL Public IP message"
 
 from apel.db.apeldb import ApelDb, Query, ApelDbException

--- a/apel/db/backends/mysql.py
+++ b/apel/db/backends/mysql.py
@@ -25,6 +25,7 @@ from apel.db.records import (BlahdRecord,
                              CloudSummaryRecord,
                              EventRecord,
                              GroupAttributeRecord,
+                             IPRecord,
                              JobRecord,
                              NormalisedSummaryRecord,
                              ProcessedRecord,
@@ -72,7 +73,8 @@ class ApelMysqlDb(object):
               CloudRecord : "CALL ReplaceCloudRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
               CloudSummaryRecord : "CALL ReplaceCloudSummaryRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
               StorageRecord: "CALL ReplaceStarRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
-              GroupAttributeRecord: "CALL ReplaceGroupAttribute(%s, %s, %s)"
+              GroupAttributeRecord: "CALL ReplaceGroupAttribute(%s, %s, %s)",
+              IPRecord: "CALL ReplaceIPRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
               }
 
     def __init__(self, host, port, username, pwd, db):

--- a/apel/db/loader/record_factory.py
+++ b/apel/db/loader/record_factory.py
@@ -18,21 +18,26 @@
 Module containing the RecordFactory class.
 '''
 
+from apel.common.message_schemas import IP_MSG_SCHEMA
 from apel.db.records.job import JobRecord
 from apel.db.records.summary import SummaryRecord
 from apel.db.records.normalised_summary import NormalisedSummaryRecord
 from apel.db.records.sync import SyncRecord
 from apel.db.records.cloud import CloudRecord
 from apel.db.records.cloud_summary import CloudSummaryRecord
+from apel.db.records.ip_record import IPRecord
 from apel.db import (JOB_MSG_HEADER, SUMMARY_MSG_HEADER,
                      NORMALISED_SUMMARY_MSG_HEADER, SYNC_MSG_HEADER,
-                     CLOUD_MSG_HEADER, CLOUD_SUMMARY_MSG_HEADER)
+                     CLOUD_MSG_HEADER, CLOUD_SUMMARY_MSG_HEADER,
+                     IP_MSG_TYPE)
 
 from apel.db.loader.car_parser import CarParser
 from apel.db.loader.aur_parser import AurParser
 from apel.db.loader.star_parser import StarParser
 from apel.db.loader.xml_parser import get_primary_ns
 
+import json
+import jsonschema
 import logging
 
 # Set up logging
@@ -79,6 +84,32 @@ class RecordFactory(object):
                     created_records = self._create_stars(msg_text)
                 else:
                     raise RecordFactoryException('XML format not recognised.')
+            # JSON format
+            elif msg_text.startswith('{'):
+                # Convert the message to a dictionary so it can be
+                # interrogated.
+                try:
+                    json_msg = json.loads(msg_text)
+                except ValueError as error:
+                    raise RecordFactoryException('Malformed JSON: %s' % error)
+
+                # Create record objects from the JSON.
+                try:
+                    if json_msg['Type'] == IP_MSG_TYPE:
+                        created_records = self._create_ip_records(json_msg)
+
+                    else:
+                        raise RecordFactoryException(
+                            'Unsupported JSON message type: %s' %
+                            json_msg['Type']
+                        )
+
+                # Catch the case where the JSON message type is not defined.
+                except KeyError as key_error:
+                    raise RecordFactoryException(
+                        'Type of JSON message not provided.'
+                    )
+
             # APEL format
             else:
                 lines = msg_text.splitlines()
@@ -114,6 +145,27 @@ class RecordFactory(object):
     ######################################################################
     # Private methods below
     ######################################################################
+
+    def _create_ip_records(self, json_msg):
+        '''Given a dictionary, attempt to return a list of IPRecord objects.'''
+        # Before attempting to create the records, verify the supplied json
+        # against the message schema.
+        try:
+            jsonschema.validate(json_msg, IP_MSG_SCHEMA)
+        # Catch the case where json_msg does not conform to the
+        # expected JSON schema for the JSON message type.
+        except jsonschema.ValidationError as validation_error:
+            raise RecordFactoryException(
+                'IP message invalid against schema: %s' % validation_error
+            )
+
+        created_records = []
+        for record_dict in json_msg['UsageRecords']:
+            ip_record = IPRecord()
+            ip_record.set_all(record_dict)
+            created_records.append(ip_record)
+
+        return created_records
 
     def _create_jrs(self, msg_text):
         '''
@@ -260,5 +312,3 @@ class RecordFactory(object):
         parser = StarParser(msg_text)
         records = parser.get_records()
         return records
-
-

--- a/apel/db/records/__init__.py
+++ b/apel/db/records/__init__.py
@@ -30,9 +30,9 @@ from event import EventRecord
 from group_attribute import GroupAttributeRecord
 from job import JobRecord
 from processed import ProcessedRecord
+from ip_record import IPRecord
 
 from storage import StorageRecord
 from summary import SummaryRecord
 from normalised_summary import NormalisedSummaryRecord
 from sync import SyncRecord
-

--- a/apel/db/records/cloud.py
+++ b/apel/db/records/cloud.py
@@ -17,7 +17,7 @@
 '''
 
 from apel.db.records import Record, InvalidRecordException
-from apel.common import parse_fqan
+from apel.common import parse_fqan_db_safe
 from datetime import datetime, timedelta
 
 
@@ -69,14 +69,7 @@ class CloudRecord(Record):
 
         # Extract the relevant information from the user fqan.
         # Keep the fqan itself as other methods in the class use it.
-        role, group, vo = parse_fqan(self._record_content['FQAN'])
-        # We can't / don't put NULL in the database, so we use 'None'
-        if role is None:
-            role = 'None'
-        if group is None:
-            group = 'None'
-        if vo is None:
-            vo = 'None'
+        role, group, vo = parse_fqan_db_safe(self._record_content['FQAN'])
 
         if self._record_content['Benchmark'] is None:
             # If Benchmark is not present in the original record the
@@ -129,5 +122,3 @@ class CloudRecord(Record):
 
         except ValueError:
             raise InvalidRecordException("Cannot parse an integer from StartTime or EndTime.")
-
-

--- a/apel/db/records/ip_record.py
+++ b/apel/db/records/ip_record.py
@@ -1,9 +1,12 @@
+"""This file contains the IPRecord class."""
+from apel.common import parse_fqan_db_safe
 from apel.db.records import Record, InvalidRecordException
 
 
 class IPRecord(Record):
-
+    """Class to represent one IP record."""
     def __init__(self):
+        """Provide the necessary lists containing message information."""
         Record.__init__(self)
         # Fields which are required by the message format.
         self._mandatory_fields = [
@@ -25,6 +28,35 @@ class IPRecord(Record):
         self._datetime_fields = ["MeasurementTime"]
 
         # This list specifies the information that goes in the database.
-        self._db_fields = self._msg_fields
+        self._db_fields = (
+            self._msg_fields[:1] +
+            ["MeasurementMonth", "MeasurementYear"] +
+            self._msg_fields[1:8] +
+            ['VO', 'VOGroup', 'VORole'] +
+            self._msg_fields[8:]
+        )
+
         # All allowed fields.
-        self._all_fields = self._msg_fields
+        self._all_fields = self._db_fields
+
+    def _check_fields(self):
+        """
+        Add extra checks to those made in every record.
+
+        Also populates fields that are extracted from other fields.
+        """
+        # First, call the parent's version.
+        Record._check_fields(self)
+
+        # Extract the relevant information from the user fqan.
+        # Keep the fqan itself as other methods in the class use it.
+        role, group, vo = parse_fqan_db_safe(self._record_content['FQAN'])
+        self._record_content['VORole'] = role
+        self._record_content['VOGroup'] = group
+        self._record_content['VO'] = vo
+
+        # Set the MeasurementMonth and MeasurementYear.
+        measurement_month = self._record_content['MeasurementTime'].month
+        measurement_year = self._record_content['MeasurementTime'].year
+        self._record_content['MeasurementMonth'] = measurement_month
+        self._record_content['MeasurementYear'] = measurement_year

--- a/apel/db/records/ip_record.py
+++ b/apel/db/records/ip_record.py
@@ -1,0 +1,30 @@
+from apel.db.records import Record, InvalidRecordException
+
+
+class IPRecord(Record):
+
+    def __init__(self):
+        Record.__init__(self)
+        # Fields which are required by the message format.
+        self._mandatory_fields = [
+            "MeasurementTime", "SiteName", "CloudType", "LocalUser",
+            "LocalGroup", "GlobalUserName", "FQAN", "IPVersion", "IPCount"
+        ]
+
+        # This list allows us to specify the order of lines when we construct
+        # records.
+        self._msg_fields = [
+            "MeasurementTime", "SiteName", "CloudComputeService", "CloudType",
+            "LocalUser", "LocalGroup", "GlobalUserName", "FQAN", "IPVersion",
+            "IPCount"
+        ]
+
+        # Fields which will have an integer stored in them
+        self._int_fields = ["IPVersion", "IPCount"]
+
+        self._datetime_fields = ["MeasurementTime"]
+
+        # This list specifies the information that goes in the database.
+        self._db_fields = self._msg_fields
+        # All allowed fields.
+        self._all_fields = self._msg_fields

--- a/apel/db/records/job.py
+++ b/apel/db/records/job.py
@@ -19,7 +19,7 @@
 from apel.db.records import Record, InvalidRecordException
 from datetime import datetime, timedelta
 from xml.dom.minidom import Document
-from apel.common import parse_fqan
+from apel.common import parse_fqan_db_safe
 import time
 
 WITHHELD_DN = 'withheld'
@@ -90,14 +90,7 @@ class JobRecord(Record):
         # Keep the fqan itself as other methods in the class use it.
         if self._record_content['FQAN'] not in ('None', None):
 
-            role, group, vo = parse_fqan(self._record_content['FQAN'])
-            # We can't / don't put NULL in the database, so we use 'None'
-            if role is None:
-                role = 'None'
-            if group is None:
-                group = 'None'
-            if vo is None:
-                vo = 'None'
+            role, group, vo = parse_fqan_db_safe(self._record_content['FQAN'])
 
             self._record_content['VORole'] = role
             self._record_content['VOGroup'] = group
@@ -313,4 +306,3 @@ class JobRecord(Record):
         # We don't want the XML declaration, because the whole XML
         # document will be assembled by another part of the program.
         return doc.documentElement.toxml()
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ MySQL-python
 python-ldap
 iso8601
 dirq
+jsonschema

--- a/schemas/cloud-extra-public-ip.sql
+++ b/schemas/cloud-extra-public-ip.sql
@@ -1,0 +1,102 @@
+-- This schema adds the tables necessary for IP accounting as a seperate
+-- resource as part of the wider Cloud Accounting system.
+
+-- IPRecords
+CREATE TABLE IPRecords (
+  UpdateTime TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  MeasurementTime DATETIME NOT NULL,
+  MeasurementMonth INT NOT NULL,
+  MeasurementYear INT NOT NULL,
+
+  SiteID INT NOT NULL,
+  CloudComputeServiceID INT,
+  CloudType VARCHAR(255) NOT NULL,
+
+  LocalUserId VARCHAR(255) NOT NULL,
+  LocalGroupId VARCHAR(255) NOT NULL,
+
+  GlobalUserNameID INT NOT NULL,
+  FQAN VARCHAR(255) NOT NULL,
+  VOID INT NOT NULL,
+  VOGroupID INT NOT NULL,
+  VORoleID INT NOT NULL,
+
+  IPVersion TINYINT NOT NULL,
+  IPCount INT NOT NULL,
+
+  PublisherDNID INT NOT NULL,
+
+  -- We want to keep one record per site, per cloud, per user, per IP version,
+  -- per month/year.
+  PRIMARY KEY (
+    SiteID, CloudComputeServiceID, GlobalUserNameID,
+    IPVersion,
+    MeasurementMonth, MeasurementYear
+  ),
+
+  -- Index the table in a way similar to the CloudRecords table.
+  INDEX (UpdateTime),
+  INDEX (GlobalUserNameID),
+  INDEX (SiteID)
+
+);
+
+DROP PROCEDURE IF EXISTS ReplaceIPRecord;
+DELIMITER //
+CREATE PROCEDURE ReplaceIPRecord(
+  measurementTime DATETIME,
+  measurementMonth INT,
+  measurementYear INT,
+  site VARCHAR(255),
+  cloudComputeService VARCHAR(255),
+  cloudType VARCHAR(255),
+  localUserId VARCHAR(255),
+  localGroupId VARCHAR(255),
+  globalUserName VARCHAR(255),
+  fqan VARCHAR(255),
+  vo VARCHAR(255),
+  voGroup VARCHAR(255),
+  voRole VARCHAR(255),
+  ipVersion TINYINT,
+  ipCount INT,
+  publisherDN VARCHAR(255)
+)
+BEGIN
+REPLACE INTO IPRecords(
+  MeasurementTime,
+  MeasurementMonth,
+  MeasurementYear,
+  SiteID,
+  CloudComputeServiceID,
+  CloudType,
+  LocalUserId,
+  LocalGroupId,
+  GlobalUserNameID,
+  FQAN,
+  VOID,
+  VOGroupID,
+  VORoleID,
+  IPVersion,
+  IPCount,
+  PublisherDNID
+)
+VALUES(
+  measurementTime,
+  measurementMonth,
+  measurementYear,
+  SiteLookUp(site),
+  CloudComputeServiceLookup(cloudComputeService),
+  cloudType,
+  localUserId,
+  localGroupId,
+  DNLookup(globalUserName),
+  fqan,
+  VOLookup(vo),
+  VOGroupLookup(voGroup),
+  VORoleLookup(voRole),
+  ipVersion,
+  ipCount,
+  DNLookup(publisherDN)
+);
+END //
+DELIMITER ;


### PR DESCRIPTION
Hi all,

This is what I've got so far in terms of adding accounting for Public IPs in a cloud system as part of wider Cloud Accounting in APEL.

Let me know you're thoughts. At the moment [Travis](https://travis-ci.org/github/gregcorbett/apel/jobs/748157851) is complaining because of a dependency issue, it seems a solvable issue as it works on a VM with older versions of dependencies,

This [commit](https://github.com/apel/apel/commit/2ecbd80081dd1fcc9aed0160dc6398c330d53f27) can / should be factored out at.