### PR TITLE
Adds timer to summariser log

### DIFF
--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -24,7 +24,7 @@ import ConfigParser
 import logging.config
 import os
 import sys
-import timeit
+import time
 
 from apel.db import ApelDb, ApelDbException
 from apel.common import set_up_logging, LOG_BREAK
@@ -35,8 +35,8 @@ def runprocess(db_config_file, config_file, log_config_file):
     '''Parse the configuration file, connect to the database and run the
        summarising process.'''
 
-    #start a timer to log how long the summarising process takes
-    start_time = timeit.default_timer()
+    # Store start time to log how long the summarising process takes
+    start_time = time.time()
 
     try:
         # Read configuration from file
@@ -123,10 +123,10 @@ def runprocess(db_config_file, config_file, log_config_file):
 
         log.info('Summarising complete.')
 
-        #end timer to output time to logs
-        elapsed_time = round(timeit.default_timer() - start_time,3)
+        # Calculate end time to output time to logs
+        elapsed_time = round(time.time() - start_time, 3)
         log.info('Summariser completed in: %s seconds' % elapsed_time)
-        
+
         log.info(LOG_BREAK)
 
     except ApelDbException, err:

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -121,11 +121,9 @@ def runprocess(db_config_file, config_file, log_config_file):
         else:
             raise ApelDbException('Unknown database type: %s' % db_type)
 
-        log.info('Summarising complete.')
-
         # Calculate end time to output time to logs
         elapsed_time = round(time.time() - start_time, 3)
-        log.info('Summariser completed in: %s seconds' % elapsed_time)
+        log.info('Summarising completed in: %s seconds', elapsed_time)
 
         log.info(LOG_BREAK)
 

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -24,6 +24,7 @@ import ConfigParser
 import logging.config
 import os
 import sys
+import timeit
 
 from apel.db import ApelDb, ApelDbException
 from apel.common import set_up_logging, LOG_BREAK
@@ -33,6 +34,9 @@ from apel import __version__
 def runprocess(db_config_file, config_file, log_config_file):
     '''Parse the configuration file, connect to the database and run the
        summarising process.'''
+
+    #start a timer to log how long the summarising process takes
+    start_time = timeit.default_timer()
 
     try:
         # Read configuration from file
@@ -118,6 +122,11 @@ def runprocess(db_config_file, config_file, log_config_file):
             raise ApelDbException('Unknown database type: %s' % db_type)
 
         log.info('Summarising complete.')
+
+        #end timer to output time to logs
+        elapsed_time = round(timeit.default_timer() - start_time,3)
+        log.info('Summariser completed in: %s seconds' % elapsed_time)
+        
         log.info(LOG_BREAK)
 
     except ApelDbException, err:


### PR DESCRIPTION
Times how long the summariser takes to complete and outputs to the log when successful.

An example:
```
...
2021-01-25 16:17:38,692 - summariser - INFO - Summarising completed in: 0.014 seconds
2021-01-25 16:17:38,692 - summariser - INFO - ========================================