### PR TITLE
Update dependencies

### DIFF
--- a/apel.spec
+++ b/apel.spec
@@ -25,7 +25,7 @@ The project is written in Python.
 %package lib
 Summary:        Libraries required for Apel Client, Server and Parsers
 Group:          Development/Languages
-Requires:       MySQL-python python-ldap python-iso8601
+Requires:       MySQL-python, python-ldap, python-iso8601, python-dirq
 Requires(pre):  shadow-utils
 
 %description lib
@@ -55,7 +55,7 @@ SSM.
 %package server
 Summary:        APEL server package
 Group:          Development/Languages
-Requires:       apel-lib >= %{version}, apel-ssm
+Requires:       apel-lib >= %{version}
 Requires(pre):  shadow-utils
 
 %description server


### PR DESCRIPTION
Resolves #211.

- Add python-dirq to lib dependencies. It was removed as a hard
  dependency from SSM so was enforced through that, but it's still
  required by the APEL code.
- Remove apel-ssm from server dependencies as it's only required by the
  client.