### PR TITLE
Travis, MySQL and testing fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,16 @@
+os: linux
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "nightly"
+  - "3.7"
 matrix:
   allow_failures:
-    - python: "nightly"
+    - python: "3.7"
   fast_finish: true
 
 # MySQL doesn't start automatically in newer build environments
 services:
   - mysql
-
-# Pin Ubuntu to Trusty for the moment for Python 2.6 support
-dist: trusty
 
 # Cache the dependencies installed by pip
 cache: pip

--- a/schemas/client.sql
+++ b/schemas/client.sql
@@ -140,7 +140,7 @@ CREATE TABLE BlahdRecords (
   VORoleID                    INT          NOT NULL, -- foreign key
   CEID                        INT          NOT NULL, -- foreign key
   GlobalJobId                 VARCHAR(255) DEFAULT NULL,
-  LrmsId                      VARCHAR(255) DEFAULT NULL,
+  LrmsId                      VARCHAR(255) DEFAULT '',
   SiteID                      INT          NOT NULL, -- foreign key
   ValidFrom                   DATETIME     DEFAULT NULL,
   ValidUntil                  DATETIME     DEFAULT NULL,

--- a/schemas/client.sql
+++ b/schemas/client.sql
@@ -146,7 +146,7 @@ CREATE TABLE BlahdRecords (
   ValidUntil                  DATETIME     DEFAULT NULL,
   Processed                   INT          DEFAULT NULL,
 
-  PRIMARY KEY(TimeStamp, SiteId, LrmsId, CEID),
+  PRIMARY KEY(TimeStamp, SiteID, LrmsId, CEID),
   INDEX BlahdJoinIdx (ValidFrom, ValidUntil, SiteID, LrmsId)
 );
 

--- a/test/test_mysql.py
+++ b/test/test_mysql.py
@@ -18,6 +18,11 @@ class MysqlTest(unittest.TestCase):
                  'CREATE DATABASE apel_unittest;')
         subprocess.call(['mysql', '-u', 'root', '-e', query])
 
+        # Use MariaDB 10.1.x defaults
+        modes = ("SET GLOBAL sql_mode = "
+                 "'NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'")
+        subprocess.call(['mysql', '-u', 'root', '-e', modes])
+
         schema_path = os.path.abspath(os.path.join('..', 'schemas',
                                                    'server.sql'))
         schema_handle = open(schema_path)


### PR DESCRIPTION
- Changes to Travis file bring our APEL CI into line with SSM (which was updated more recently).
- MySQL testing has been changed to use MariaDB defaults from 10.1.x as 10.2.x defaults don't work with the current schemas.
- Some fixes to the client schema required by non-ancient versions of MySQL (or just typos).

Lack of update script recorded in https://github.com/apel/apel/issues/243