### PR TITLE
Cap mock below 4.0.0

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,6 +5,6 @@
 
 unittest2
 coveralls<=1.2.0
-mock
+mock<4.0.0
 codecov
 pre-commit


### PR DESCRIPTION
- version 4 dropped support for Python 2.7