### PR TITLE
Cap python-ldap below 3.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Base requirements for apel
 
 MySQL-python
-python-ldap
+python-ldap<3.4.0  # python-ldap-3.4.0 dropped support for Python 2
 iso8601
 dirq


### PR DESCRIPTION
3.4.0 dropped support for Python 2
  - https://github.com/python-ldap/python-ldap/releases/tag/python-ldap-3.4.0