### PR TITLE
Limit python-ldap version while we still need Py 2

### DIFF
--- a/apel.spec
+++ b/apel.spec
@@ -25,7 +25,7 @@ The project is written in Python.
 %package lib
 Summary:        Libraries required for Apel Client, Server and Parsers
 Group:          Development/Languages
-Requires:       MySQL-python, python-ldap, python-iso8601, python-dirq
+Requires:       MySQL-python, python-ldap < 3.4.0 , python-iso8601, python-dirq
 Requires(pre):  shadow-utils
 
 %description lib


### PR DESCRIPTION
Resolves #286 .

Decided to only add it to the RPM SPEC file as that's the package that is likely to be used on a Python 2 system, while the setup.py is likely to be used on a Python 3 system.