### PR TITLE
Changes for basic client support of HEPscore23

### DIFF
--- a/apel/db/records/job.py
+++ b/apel/db/records/job.py
@@ -76,8 +76,7 @@ class JobRecord(Record):
         self._datetime_fields = ["StartTime", "EndTime"]
 
         # Acceptable values for the ServiceLevelType field, not case-sensitive
-        self._valid_slts = ["si2k", "hepspec"]
-
+        self._valid_slts = ["si2k", "hepspec", "hepscore23"]
 
     def _check_fields(self):
         '''

--- a/conf/client.cfg
+++ b/conf/client.cfg
@@ -28,7 +28,7 @@ ldap_port = 2170
 ## To manually set specs for all jobs (not just local ones), configure lines
 ## like the following named "manual_spec" followed by consecutive integers for
 ## however many batch systems are relevant. The value should be a unique name
-## for the system, then the spec type ('HEPSPEC' or 'Si2k') and the spec value.
+## for the system, then the spec type ('HEPscore23', 'HEPSPEC' or 'Si2k') and the spec value.
 # manual_spec1 = grid10.uni.ac.uk:1234/grid10.uni.ac.uk-condor,HEPSPEC,10.0
 # manual_spec2 = grid22.uni.ac.uk:1234/grid22.uni.ac.uk-condor,HEPSPEC,15.0
 # manual_spec3 = grid35.uni.ac.uk:1234/grid35.uni.ac.uk-condor,HEPSPEC,15.0

--- a/test/test_job_record.py
+++ b/test/test_job_record.py
@@ -18,9 +18,8 @@ class TestJobRecord(unittest.TestCase):
 
         record = JobRecord()
         self.assertRaises(InvalidRecordException, record._check_factor, 'unknown', 1)
-        # currently only si2k and hepspec are supported
-        # add values here if you need to add
-        factors = ['si2k', 'hepspec']
+        # Add values here if you need to add more supported benchmark types.
+        factors = ['si2k', 'hepspec', 'hepscore23']
         for factor in factors:
             try:
                 record._check_factor(factor, 1)


### PR DESCRIPTION
- Allow hepscore23 as a service level type in Python job record objects and update test.
- Update config docs for manual_spec.