### PR TITLE
Update default hostname for BDII

### DIFF
--- a/apel/ldap/query.py
+++ b/apel/ldap/query.py
@@ -49,7 +49,7 @@ def parse_ce_capability(capability_string):
     return decimal_value
 
 
-def fetch_specint(site, host='lcg-bdii.cern.ch', port=2170):
+def fetch_specint(site, host='lcg-bdii.egi.eu', port=2170):
     '''
     Imports benchmark data from LDAP. Current implementation
     is able to fetch data according to way described here:

--- a/conf/client.cfg
+++ b/conf/client.cfg
@@ -10,7 +10,7 @@ password =
 enabled = true
 # The GOCDB site name
 site_name =
-ldap_host = lcg-bdii.cern.ch
+ldap_host = lcg-bdii.egi.eu
 ldap_port = 2170
 
 ## The following information is necessary for


### PR DESCRIPTION
- CERN BDII is being decommissioned so this changes it to the EGI one which is still available.

As requested by CERN ops.