### PR TITLE
[GT-170] Filter non-DNs from banned and extras files at read time.

### DIFF
--- a/bin/retrieve_dns.py
+++ b/bin/retrieve_dns.py
@@ -156,14 +156,21 @@ def dns_from_dom(dom):
 
 def dns_from_file(path):
     '''
-    Get all the lines in a file and return them as a list of strings.  We
-    assume that they're DNs, but we'll check later.
+    Get all the DNs in a file and return them as a list of strings.
     '''
+    # A list to store the DNs in.
+    dns = []
 
     with open(path) as dn_file:
-        dns = dn_file.readlines()
-    # get rid of any whitespace in the list of strings
-    dns = [dn.strip() for dn in dns]
+        line_list = dn_file.readlines()
+
+        for line in line_list:
+            # Get rid of any whitespace in each string.
+            whitespace_free_line = line.strip()
+            # Filter out any non DNs.
+            if verify_dn(whitespace_free_line):
+                dns.append(whitespace_free_line)
+
     return dns
 
 
@@ -294,9 +301,6 @@ def runprocess(config_file):
                     new_dn_file.write(dn)
                     new_dn_file.write('\n')
                     added += 1
-                elif dn.lstrip().startswith("#"):
-                    # Ignore comment lines starting with "#"
-                    log.debug("Comment ignored: %s", dn)
                 else:
                     # We haven't accepted the DN, so write it to the log file.
                     log.warning("DN not valid and won't be added: %s", dn)

--- a/test/test_retrieve_dns.py
+++ b/test/test_retrieve_dns.py
@@ -111,6 +111,30 @@ class RunprocessTestCase(unittest.TestCase):
         c.gocdb_url = "not.a.host"
         mock_config.return_value = c
 
+    def check_dn_file_length(self, file_type, expected_result):
+        """Check the given file type for the expected number of DNs."""
+        dn_list = bin.retrieve_dns.dns_from_file(self.files[file_type]['path'])
+
+        # Determine the actual number of DNs retrieved from the file.
+        actual_result = len(dn_list)
+
+        self.assertEqual(
+            actual_result,
+            expected_result,
+            "%i DNs were extracted from the %s DN file. Expecting %i." % (
+                actual_result,
+                file_type,
+                expected_result,
+            )
+        )
+
+    def test_dns_from_file_number(self):
+        """Test dns_from_file returns the expected number of DNs."""
+        # Test dns_from_file using the test extra DNs file.
+        self.check_dn_file_length('extra', 2)
+        # Test dns_from_file using the test banned DNs file.
+        self.check_dn_file_length('ban', 1)
+
     def test_next_link_from_dom(self):
         """Test a next link is correctly retrieved from a xml string."""
         xml_test_string = """<results>

--- a/test/test_retrieve_dns.py
+++ b/test/test_retrieve_dns.py
@@ -96,8 +96,8 @@ class RunprocessTestCase(unittest.TestCase):
             self.files[item] = dict(zip(('handle', 'path'), tempfile.mkstemp()))
 
         os.write(self.files['dn']['handle'], "/dn/1\n/dn/2\n".encode("utf-8"))
-        os.write(self.files['extra']['handle'], "#comment\n/extra/dn\n/banned/dn".encode("utf-8"))
-        os.write(self.files['ban']['handle'], "/banned/dn".encode("utf-8"))
+        os.write(self.files['extra']['handle'], "#comment\n/extra/dn\n/banned/dn\nNot a DN.".encode("utf-8"))
+        os.write(self.files['ban']['handle'], "Not a DN.\n/banned/dn\n#comment".encode("utf-8"))
 
         for item in list(self.files.values()):
             os.close(item['handle'])


### PR DESCRIPTION
Resolves #310 

This will mean the auth component will log the number of DNs fetched from the files, and not the number of lines.

This PR also:
- extends the existing test cases with a mix of additional DNs, new non-DN strings and comments.
- adds a new test case (and helper method) to check the correct number of DNs are extracted from files.