### PR TITLE
Add accelerator records and summaries

### DIFF
--- a/apel/common/json_utils.py
+++ b/apel/common/json_utils.py
@@ -1,4 +1,20 @@
-import json
+"""
+   Copyright (C) 2023 STFC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+Helper methods to perform JSON operations.
+"""
 
 JSON_MSG_BOILERPLATE = """{
     "Type": "%s",
@@ -6,30 +22,8 @@ JSON_MSG_BOILERPLATE = """{
     "UsageRecords": %s
 }"""
 
-
-def to_string(json_dict, dlm=''):
-    """ Convert a dict into a valid json string """
-    json_string = str(json_dict).replace("'", '"')
-
-    try:
-        json_dict_conv = json.loads(json_string)
-    except json.decoder.JSONDecodeError:
-        raise Exception('Unable to generate valid JSON. Make sure speech marks or apostrophes are escaped correctly.')
-
-    if json_dict != json_dict_conv:
-        raise Exception('JSON conversion unsuccessful because input dict does not match reconstructed dict.')
-
-    return json_string
-
-def to_dict(json_string):
-    """ Convert a valid json string into a dict """
-
-    try:
-        json_dict = json.loads(json_string)
-    except json.decoder.JSONDecodeError as e:
-        print(e)
-        raise Exception(e, '\n\nJSON string is not valid.')
-
 def to_message(type, version, *usage_records):
     """ Generate JSON message format """
-    return (JSON_MSG_BOILERPLATE % (type, version, list(usage_records))).replace("'", '"')
+    return (
+        JSON_MSG_BOILERPLATE % (type, version, list(usage_records))
+    ).replace("'", '"')

--- a/apel/common/json_utils.py
+++ b/apel/common/json_utils.py
@@ -1,0 +1,35 @@
+import json
+
+JSON_MSG_BOILERPLATE = """{
+    "Type": "%s",
+    "Version": "%s",
+    "UsageRecords": %s
+}"""
+
+
+def to_string(json_dict, dlm=''):
+    """ Convert a dict into a valid json string """
+    json_string = str(json_dict).replace("'", '"')
+
+    try:
+        json_dict_conv = json.loads(json_string)
+    except json.decoder.JSONDecodeError:
+        raise Exception('Unable to generate valid JSON. Make sure speech marks or apostrophes are escaped correctly.')
+
+    if json_dict != json_dict_conv:
+        raise Exception('JSON conversion unsuccessful because input dict does not match reconstructed dict.')
+
+    return json_string
+
+def to_dict(json_string):
+    """ Convert a valid json string into a dict """
+
+    try:
+        json_dict = json.loads(json_string)
+    except json.decoder.JSONDecodeError as e:
+        print(e)
+        raise Exception(e, '\n\nJSON string is not valid.')
+
+def to_message(type, version, *usage_records):
+    """ Generate JSON message format """
+    return (JSON_MSG_BOILERPLATE % (type, version, list(usage_records))).replace("'", '"')

--- a/apel/common/message_schemas.py
+++ b/apel/common/message_schemas.py
@@ -198,3 +198,190 @@ ACCELERATOR_MSG_SCHEMA = {
     }
 }
 
+ACCELERATOR_SUMMARY_MSG_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "http://localhost/schema.json",
+    "type": "object",
+    "title": "Accelerator summary message schema root",
+    "description": "This schema defines the basic conditions an accelerator summary message must meet",
+    "required": [
+        "Type",
+        "Version",
+        "UsageRecords"
+    ],
+    "properties": {
+        "Type": {
+            "$id": "#/properties/Type",
+            "title": "JSON message type",
+            "type": "string",
+            "const": "APEL-Accelerator-summary-message"
+        },
+        "Version": {
+            "$id": "#/properties/Version",
+            "title": "JSON message version",
+            "type": "string",
+            "enum": [
+                "0.1"
+            ]
+        },
+        "UsageRecords": {
+            "$id": "#/properties/UsageRecords",
+            "title": "Accelerator Summary usage records",
+            "description": "The list of records matching Accelerator summary requirements",
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1000,
+            "items": {
+                "$id": "#/properties/UsageRecords/items",
+                "type": "object",
+                "required": [
+                    "Month",
+                    "Year",
+                    "AssociatedRecordType",
+                    "SiteName",
+                    "Count",
+                    "AvailableDuration",
+                    "Type",
+                    "NumberOfRecords"
+                ],
+                "properties": {
+                    "Month": {
+                        "$id": "#/properties/UsageRecords/items/properties/Month",
+                        "type": "integer",
+                        "enum": [
+                            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12
+                        ]
+                    },
+                    "Year": {
+                        "$id": "#/properties/UsageRecords/items/properties/Year",
+                        "type": "integer",
+                        "examples": [
+                            2021
+                        ],
+                        "minimum": 2000,
+                        "maximum": current_year
+                    },
+                    "AssociatedRecordType": {
+                        "$id": "#/properties/UsageRecords/items/properties/AssociatedRecordType",
+                        "type": "string",
+                        "enum": [
+                            "cloud",
+                            "job"
+                        ]
+                    },
+                    "GlobalUserName": {
+                        "$id": "#/properties/UsageRecords/items/properties/GlobalUserName",
+                        "anyOf": [
+                            {"type": "string"},
+                            {"type": "null"}
+                        ],
+                        "examples": [
+                            "GlobalUserA"
+                        ]
+                    },
+                    "FQAN": {
+                        "$id": "#/properties/UsageRecords/items/properties/FQAN",
+                        "type": "string",
+                        "examples": [
+                            "None",
+                            "project1",
+                            "/fedcloud.egi.eu/Role=NULL/Capability=NULL"
+                        ]
+                    },
+                    "SiteName": {
+                        "$id": "#/properties/UsageRecords/items/properties/SiteName",
+                        "type": "string",
+                        "examples": [
+                            "TEST-SITE"
+                        ]
+                    },
+                    "Count": {
+                        "$id": "#/properties/UsageRecords/items/properties/Count",
+                        "description": "The number of Accelerators used",
+                        "type": "number",
+                        "examples": [
+                            1.4
+                        ]
+                    },
+                    "Cores": {
+                        "$id": "#/properties/UsageRecords/items/properties/Cores",
+                        "description": "The number of cores for this Accelerator type",
+                        "anyOf": [
+                            {"type": "integer"},
+                            {"type": "null"}
+                        ],
+                        "examples": [
+                            128
+                        ]
+                    },
+                    "ActiveDuration": {
+                        "$id": "#/properties/UsageRecords/items/properties/ActiveDuration",
+                        "description": "The recorded time in seconds that accelerators were explicitly active for (NOT IMPLEMENTED)",
+                        "anyOf": [
+                            {"type": "integer"},
+                            {"type": "null"}
+                        ],
+                        "examples": [
+                            40
+                        ]
+                    },
+                    "AvailableDuration": {
+                        "$id": "#/properties/UsageRecords/items/properties/AvailableDuration",
+                        "description": "The wall time in seconds that accelerators were held for",
+                        "type": "integer",
+                        "examples": [
+                            4000
+                        ]
+                    },
+                    "BenchmarkType": {
+                        "$id": "#/properties/UsageRecords/items/properties/BenchmarkType",
+                        "description": "The identifier for the accelerator benchmark",
+                        "anyOf": [
+                            {"type": "string"},
+                            {"type": "null"}
+                        ],
+                        "examples": [
+                            "HEPSPEC"
+                        ]
+                    },
+                    "Benchmark": {
+                        "$id": "#/properties/UsageRecords/items/properties/Benchmark",
+                        "description": "The benchmark score",
+                        "anyOf": [
+                            {"type": "number"},
+                            {"type": "null"}
+                        ],
+                        "examples": [
+                            9000.01
+                        ]
+                    },
+                    "Type": {
+                        "$id": "#/properties/UsageRecords/items/properties/Type",
+                        "description": "The general descriptor for accelerator",
+                        "type": "string",
+                        "enum": [
+                            "Accelerator",
+                            "FPGA",
+                            "Other"
+                        ]
+                    },
+                    "Model": {
+                        "$id": "#/properties/UsageRecords/items/properties/Model",
+                        "description": "Specific model of accelerator type",
+                        "type": "string",
+                        "examples": [
+                            "VendorA-ModelA",
+                            "VendorA-ModelB"
+                        ]
+                    },
+                    "NumberOfRecords": {
+                        "$id": "#/properties/UsageRecords/items/properties/NumberOfRecords",
+                        "description": "Total combined individual records in this summary",
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                }
+            }
+        }
+    }
+}

--- a/apel/common/message_schemas.py
+++ b/apel/common/message_schemas.py
@@ -1,0 +1,200 @@
+"""A file to store message schemas for JSON based messages"""
+
+import datetime
+
+current_year = datetime.datetime.now().year
+
+ACCELERATOR_MSG_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "http://localhost/schema.json",
+    "type": "object",
+    "title": "Accelerator message schema root",
+    "description": "This schema defines the basic conditions an accelerator message must meet",
+    "required": [
+        "Type",
+        "Version",
+        "UsageRecords"
+    ],
+    "properties": {
+        "Type": {
+            "$id": "#/properties/Type",
+            "title": "JSON message type",
+            "type": "string",
+            "const": "APEL-Accelerator-message"
+        },
+        "Version": {
+            "$id": "#/properties/Version",
+            "title": "JSON message version",
+            "type": "string",
+            "enum": [
+                "0.1"
+            ]
+        },
+        "UsageRecords": {
+            "$id": "#/properties/UsageRecords",
+            "title": "Accelerator usage records",
+            "description": "The list of records matching Accelerator record requirements",
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1000,
+            "items": {
+                "$id": "#/properties/UsageRecords/items",
+                "type": "object",
+                "required": [
+                    "MeasurementMonth",
+                    "MeasurementYear",
+                    "AssociatedRecordType",
+                    "AssociatedRecord",
+                    "FQAN",
+                    "SiteName",
+                    "Count",
+                    "AvailableDuration",
+                    "Type",
+                ],
+                "properties": {
+                    "MeasurementMonth": {
+                        "$id": "#/properties/UsageRecords/items/properties/MeasurementMonth",
+                        "type": "integer",
+                        "enum": [
+                            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12
+                        ]
+                    },
+                    "MeasurementYear": {
+                        "$id": "#/properties/UsageRecords/items/properties/MeasurementYear",
+                        "type": "integer",
+                        "examples": [
+                            2021
+                        ],
+                        "minimum": 2000,
+                        "maximum": current_year
+                    },
+                    "AssociatedRecordType": {
+                        "$id": "#/properties/UsageRecords/items/properties/AssociatedRecordType",
+                        "type": "string",
+                        "enum": [
+                            "cloud",
+                            "job"
+                        ]
+                    },
+                    "AssociatedRecord": {
+                        "$id": "#/properties/UsageRecords/items/properties/AssociatedRecord",
+                        "type": "string",
+                        "examples": [
+                            "a-fake-vmuuid"
+                        ]
+                    },
+                    "GlobalUserName": {
+                        "$id": "#/properties/UsageRecords/items/properties/GlobalUserName",
+                        "anyOf": [
+                            {"type": "string"},
+                            {"type": "null"}
+                        ],
+                        "examples": [
+                            "null",
+                            "GlobalUserA"
+                        ]
+                    },
+                    "FQAN": {
+                        "$id": "#/properties/UsageRecords/items/properties/FQAN",
+                        "type": "string",
+                        "examples": [
+                            "None",
+                            "project1",
+                            "/fedcloud.egi.eu/Role=NULL/Capability=NULL"
+                        ]
+                    },
+                    "SiteName": {
+                        "$id": "#/properties/UsageRecords/items/properties/SiteName",
+                        "type": "string",
+                        "examples": [
+                            "TEST-SITE"
+                        ]
+                    },
+                    "Count": {
+                        "$id": "#/properties/UsageRecords/items/properties/Count",
+                        "description": "The number of Accelerators used",
+                        "type": "number",
+                        "examples": [
+                            1.4
+                        ]
+                    },
+                    "Cores": {
+                        "$id": "#/properties/UsageRecords/items/properties/Cores",
+                        "description": "The number of cores for this Accelerator type",
+                        "anyOf": [
+                            {"type": "integer"},
+                            {"type": "null"}
+                        ],
+                        "examples": [
+                            128
+                        ]
+                    },
+                    "ActiveDuration": {
+                        "$id": "#/properties/UsageRecords/items/properties/ActiveDuration",
+                        "description": "The recorded time in seconds that accelerators were explicitly active for (NOT IMPLEMENTED)",
+                        "anyOf": [
+                            {"type": "integer"},
+                            {"type": "null"}
+                        ],
+                        "examples": [
+                            40
+                        ]
+                    },
+                    "AvailableDuration": {
+                        "$id": "#/properties/UsageRecords/items/properties/AvailableDuration",
+                        "description": "The wall time in seconds that accelerators were held for",
+                        "type": "integer",
+                        "examples": [
+                            4000
+                        ]
+                    },
+                    "BenchmarkType": {
+                        "$id": "#/properties/UsageRecords/items/properties/BenchmarkType",
+                        "description": "The identifier for the accelerator benchmark",
+                        "anyOf": [
+                            {"type": "string"},
+                            {"type": "null"}
+                        ],
+                        "examples": [
+                            "null",
+                            "HEPSPEC"
+                        ]
+                    },
+                    "Benchmark": {
+                        "$id": "#/properties/UsageRecords/items/properties/Benchmark",
+                        "description": "The benchmark score",
+                        "anyOf": [
+                            {"type": "number"},
+                            {"type": "null"}
+                        ],
+                        "examples": [
+                            9000.01
+                        ]
+                    },
+                    "Type": {
+                        "$id": "#/properties/UsageRecords/items/properties/Type",
+                        "description": "The general descriptor for accelerator",
+                        "type": "string",
+                        "enum": [
+                            "GPU",
+                            "FPGA",
+                            "Other"
+                        ]
+                    },
+                    "Model": {
+                        "$id": "#/properties/UsageRecords/items/properties/Model",
+                        "description": "Specific model of accelerator type",
+                        "type": "string",
+                        "examples": [
+                            "VendorA-ModelA",
+                            "VendorA-ModelB"
+                        ]
+                    }
+                }
+                # We can impose Model restrictions conditional on type using the allOf operator
+                # "allOf": [ ]
+            }
+        }
+    }
+}
+

--- a/apel/db/__init__.py
+++ b/apel/db/__init__.py
@@ -21,5 +21,6 @@ NORMALISED_SUMMARY_MSG_HEADER = "APEL-summary-job-message: v0.3"
 SYNC_MSG_HEADER = "APEL-sync-message: v0.1"
 CLOUD_MSG_HEADER = 'APEL-cloud-message: v0.4'
 CLOUD_SUMMARY_MSG_HEADER = 'APEL-cloud-summary-message: v0.4'
+ACCELERATOR_MSG_TYPE = 'APEL-Accelerator-message'
 
 from apel.db.apeldb import ApelDb, Query, ApelDbException

--- a/apel/db/__init__.py
+++ b/apel/db/__init__.py
@@ -22,5 +22,6 @@ SYNC_MSG_HEADER = "APEL-sync-message: v0.1"
 CLOUD_MSG_HEADER = 'APEL-cloud-message: v0.4'
 CLOUD_SUMMARY_MSG_HEADER = 'APEL-cloud-summary-message: v0.4'
 ACCELERATOR_MSG_TYPE = 'APEL-Accelerator-message'
+ACCELERATOR_SUMMARY_MSG_TYPE = 'APEL-Accelerator-summary-message'
 
 from apel.db.apeldb import ApelDb, Query, ApelDbException

--- a/apel/db/__init__.py
+++ b/apel/db/__init__.py
@@ -21,7 +21,7 @@ NORMALISED_SUMMARY_MSG_HEADER = "APEL-summary-job-message: v0.3"
 SYNC_MSG_HEADER = "APEL-sync-message: v0.1"
 CLOUD_MSG_HEADER = 'APEL-cloud-message: v0.4'
 CLOUD_SUMMARY_MSG_HEADER = 'APEL-cloud-summary-message: v0.4'
-ACCELERATOR_MSG_TYPE = 'APEL-Accelerator-message'
-ACCELERATOR_SUMMARY_MSG_TYPE = 'APEL-Accelerator-summary-message'
+ACCELERATOR_MSG_TYPE = "APEL-Accelerator-message"
+ACCELERATOR_SUMMARY_MSG_TYPE = "APEL-Accelerator-summary-message"
 
 from apel.db.apeldb import ApelDb, Query, ApelDbException

--- a/apel/db/backends/mysql.py
+++ b/apel/db/backends/mysql.py
@@ -25,6 +25,7 @@ from apel.db.records import (BlahdRecord,
                              CloudSummaryRecord,
                              EventRecord,
                              GroupAttributeRecord,
+                             AcceleratorRecord,
                              JobRecord,
                              NormalisedSummaryRecord,
                              ProcessedRecord,
@@ -72,7 +73,8 @@ class ApelMysqlDb(object):
               CloudRecord : "CALL ReplaceCloudRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
               CloudSummaryRecord : "CALL ReplaceCloudSummaryRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
               StorageRecord: "CALL ReplaceStarRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
-              GroupAttributeRecord: "CALL ReplaceGroupAttribute(%s, %s, %s)"
+              GroupAttributeRecord: "CALL ReplaceGroupAttribute(%s, %s, %s)",
+              AcceleratorRecord: "CALL ReplaceAcceleratorRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
               }
 
     def __init__(self, host, port, username, pwd, db):
@@ -158,6 +160,7 @@ class ApelMysqlDb(object):
 
             for record in record_list:
                 values = record.get_db_tuple(source)
+                # log.debug('Keys: %s', record._db_fields)
                 log.debug('Values: %s', values)
                 if type(record) in (StorageRecord, GroupAttributeRecord):
                     # These types can be found in the same record list, so need

--- a/apel/db/backends/mysql.py
+++ b/apel/db/backends/mysql.py
@@ -57,7 +57,8 @@ class ApelMysqlDb(object):
                     ProcessedRecord : 'VProcessedFiles',
                     SummaryRecord : 'VSummaries',
                     StorageRecord: 'VStarRecords',
-                    AcceleratorSummary: 'AcceleratorSummaries'}
+                    AcceleratorSummary: 'AcceleratorSummaries',
+                    }
 
     # These simply need to have the same number of arguments as the stored procedures defined in the database schemas.
     INSERT_PROCEDURES = {
@@ -77,7 +78,7 @@ class ApelMysqlDb(object):
               StorageRecord: "CALL ReplaceStarRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
               GroupAttributeRecord: "CALL ReplaceGroupAttribute(%s, %s, %s)",
               AcceleratorRecord: "CALL ReplaceAcceleratorRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
-              AcceleratorSummary: "CALL ReplaceAcceleratorSummaryRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"
+              AcceleratorSummary: "CALL ReplaceAcceleratorSummaryRecord(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
               }
 
     def __init__(self, host, port, username, pwd, db):
@@ -164,7 +165,6 @@ class ApelMysqlDb(object):
 
             for record in record_list:
                 values = record.get_db_tuple(source)
-                # log.debug('Keys: %s', record._db_fields)
                 log.debug('Values: %s', values)
                 if type(record) in (StorageRecord, GroupAttributeRecord):
                     # These types can be found in the same record list, so need
@@ -412,14 +412,14 @@ class ApelMysqlDb(object):
             raise
 
     def summarise_accelerators(self):
-        '''
+        """
         Aggregate the AcceleratorRecords table and put the results in the
         AcceleratorSummaries table.  This method does this by calling the
         SummariseAccelerators procedure.
 
         Any failure will result in the entire transaction being rolled
         back.
-        '''
+        """
         try:
             # prevent MySQLdb from raising
             # 'MySQL server has gone' exception
@@ -428,11 +428,11 @@ class ApelMysqlDb(object):
             c = self.db.cursor()
 
             log.info("Summarising Accelerator records...")
-            c.callproc(self._summarise_accelerators_proc, ())
+            c.callproc(self._summarise_accelerators_proc)
             log.info("Done.")
 
             self.db.commit()
-        except MySQLdb.Error, e:
+        except MySQLdb.Error as e:
             log.error("A mysql error occurred: %s", e)
             log.error("Any transaction will be rolled back.")
 

--- a/apel/db/loader/loader.py
+++ b/apel/db/loader/loader.py
@@ -199,6 +199,7 @@ class Loader(object):
                     apel.db.records.cloud_summary.CloudSummaryRecord:
                     'Cloud Summary',
                     apel.db.records.accelerator.AcceleratorRecord: 'Accelerator',
+                    apel.db.records.accelerator_summary.AcceleratorSummary: 'Accelerator Summary',
                     }
 
         log.info('Loading message from %s', signer)

--- a/apel/db/loader/loader.py
+++ b/apel/db/loader/loader.py
@@ -199,7 +199,8 @@ class Loader(object):
                     apel.db.records.cloud_summary.CloudSummaryRecord:
                     'Cloud Summary',
                     apel.db.records.accelerator.AcceleratorRecord: 'Accelerator',
-                    apel.db.records.accelerator_summary.AcceleratorSummary: 'Accelerator Summary',
+                    apel.db.records.accelerator_summary.AcceleratorSummary:
+                    'Accelerator Summary',
                     }
 
         log.info('Loading message from %s', signer)

--- a/apel/db/loader/loader.py
+++ b/apel/db/loader/loader.py
@@ -197,7 +197,9 @@ class Loader(object):
                     apel.db.records.sync.SyncRecord: 'Sync',
                     apel.db.records.cloud.CloudRecord: 'Cloud',
                     apel.db.records.cloud_summary.CloudSummaryRecord:
-                    'Cloud Summary'}
+                    'Cloud Summary',
+                    apel.db.records.accelerator.AcceleratorRecord: 'Accelerator',
+                    }
 
         log.info('Loading message from %s', signer)
 

--- a/apel/db/loader/record_factory.py
+++ b/apel/db/loader/record_factory.py
@@ -19,6 +19,7 @@ Module containing the RecordFactory class.
 '''
 
 from apel.common.message_schemas import ACCELERATOR_MSG_SCHEMA
+from apel.common.message_schemas import ACCELERATOR_SUMMARY_MSG_SCHEMA
 from apel.db.records.job import JobRecord
 from apel.db.records.summary import SummaryRecord
 from apel.db.records.normalised_summary import NormalisedSummaryRecord
@@ -26,10 +27,11 @@ from apel.db.records.sync import SyncRecord
 from apel.db.records.cloud import CloudRecord
 from apel.db.records.cloud_summary import CloudSummaryRecord
 from apel.db.records.accelerator import AcceleratorRecord
+from apel.db.records.accelerator_summary import AcceleratorSummary
 from apel.db import (JOB_MSG_HEADER, SUMMARY_MSG_HEADER,
                      NORMALISED_SUMMARY_MSG_HEADER, SYNC_MSG_HEADER,
                      CLOUD_MSG_HEADER, CLOUD_SUMMARY_MSG_HEADER,
-                     ACCELERATOR_MSG_TYPE)
+                     ACCELERATOR_MSG_TYPE, ACCELERATOR_SUMMARY_MSG_TYPE)
 
 from apel.db.loader.car_parser import CarParser
 from apel.db.loader.aur_parser import AurParser
@@ -97,6 +99,8 @@ class RecordFactory(object):
                 try:
                     if json_msg['Type'] == ACCELERATOR_MSG_TYPE:
                         created_records = self._create_accelerator_records(json_msg)
+                    elif json_msg['Type'] == ACCELERATOR_SUMMARY_MSG_TYPE:
+                        created_records = self._create_accelerator_summaries(json_msg)
                     else:
                         raise RecordFactoryException(
                             'Unsupported JSON message type: %s' %
@@ -174,6 +178,12 @@ class RecordFactory(object):
 
         self._validate_json(json_msg, ACCELERATOR_MSG_SCHEMA)
         return self._unpack_json_records(json_msg, AcceleratorRecord)
+
+    def _create_accelerator_summaries(self, json_msg):
+        '''Attempt to convert an accelerator summary record dict into a list of AcceleratorSummary objects.'''
+
+        self._validate_json(json_msg, ACCELERATOR_SUMMARY_MSG_SCHEMA)
+        return self._unpack_json_records(json_msg, AcceleratorSummary)
 
 
     def _create_jrs(self, msg_text):

--- a/apel/db/loader/record_factory.py
+++ b/apel/db/loader/record_factory.py
@@ -150,22 +150,27 @@ class RecordFactory(object):
     ######################################################################
 
     def _validate_json(self, js, schema):
-        '''Run jsonschema validate on JSON given a schema otherwise raise a friendly error'''
-
+        """Run jsonschema validate on JSON given a schema
+            otherwise raise a friendly error"""
         try:
             jsonschema.validate(js, schema)
         # Catch the case where json_msg does not conform to the
         # expected JSON schema for the JSON message type.
         except jsonschema.ValidationError as validation_error:
             msg_type = schema['properties']['Type']['const']
+
             raise RecordFactoryException(
-                'JSON message invalid against %s schema: %s' % (msg_type, validation_error)
+                "JSON message invalid against %s schema: %s" % (
+                    msg_type,
+                    validation_error
+                )
             )
 
     def _unpack_json_records(self, js, RecordType):
-        '''Loop through UsageRecords in JSON and return a set of populated RecordType objects'''
-
+        """Loop through UsageRecords in JSON and
+            return a set of populated RecordType objects"""
         created_records = []
+
         for record_dict in js['UsageRecords']:
             record = RecordType()
             record.set_all(record_dict)
@@ -174,24 +179,24 @@ class RecordFactory(object):
         return created_records
 
     def _create_accelerator_records(self, json_msg):
-        '''Attempt to convert an accelerator record dict into a list of AcceleratorRecord objects.'''
-
+        """Attempt to convert an accelerator record dict into
+            a list of AcceleratorRecord objects."""
         self._validate_json(json_msg, ACCELERATOR_MSG_SCHEMA)
+
         return self._unpack_json_records(json_msg, AcceleratorRecord)
 
     def _create_accelerator_summaries(self, json_msg):
-        '''Attempt to convert an accelerator summary record dict into a list of AcceleratorSummary objects.'''
-
+        """Attempt to convert an accelerator summary record dict into
+             a list of AcceleratorSummary objects."""
         self._validate_json(json_msg, ACCELERATOR_SUMMARY_MSG_SCHEMA)
-        return self._unpack_json_records(json_msg, AcceleratorSummary)
 
+        return self._unpack_json_records(json_msg, AcceleratorSummary)
 
     def _create_jrs(self, msg_text):
         '''
         Given the text from a job record message, create a list of
         JobRecord objects and return it.
         '''
-
         msg_text = msg_text.strip()
 
         records = msg_text.split('%%')

--- a/apel/db/loader/record_factory.py
+++ b/apel/db/loader/record_factory.py
@@ -33,6 +33,8 @@ from apel.db.loader.aur_parser import AurParser
 from apel.db.loader.star_parser import StarParser
 from apel.db.loader.xml_parser import get_primary_ns
 
+import json
+import jsonschema
 import logging
 
 # Set up logging
@@ -79,6 +81,31 @@ class RecordFactory(object):
                     created_records = self._create_stars(msg_text)
                 else:
                     raise RecordFactoryException('XML format not recognised.')
+            # JSON format
+            elif msg_text.startswith('{'):
+                # Convert the message to a dictionary so it can be
+                # interrogated.
+                try:
+                    json_msg = json.loads(msg_text)
+                except ValueError as error:
+                    raise RecordFactoryException('Malformed JSON: %s' % error)
+
+                # Create record objects from the JSON.
+                try:
+                    if json_msg['Type'] == 'message_type':
+                        raise NotImplementedError
+                    else:
+                        raise RecordFactoryException(
+                            'Unsupported JSON message type: %s' %
+                            json_msg['Type']
+                        )
+
+                # Catch the case where the JSON message type is not defined.
+                except KeyError as key_error:
+                    raise RecordFactoryException(
+                        'Type of JSON message not provided.'
+                    )
+
             # APEL format
             else:
                 lines = msg_text.splitlines()
@@ -114,6 +141,30 @@ class RecordFactory(object):
     ######################################################################
     # Private methods below
     ######################################################################
+
+    def _validate_json(self, js, schema):
+        '''Run jsonschema validate on JSON given a schema otherwise raise a friendly error'''
+
+        try:
+            jsonschema.validate(js, schema)
+        # Catch the case where json_msg does not conform to the
+        # expected JSON schema for the JSON message type.
+        except jsonschema.ValidationError as validation_error:
+            raise RecordFactoryException(
+                'JSON message invalid against schema: %s' % validation_error
+            )
+
+    def _unpack_json_records(self, js, RecordType):
+        '''Loop through UsageRecords in JSON and return a set of populated RecordType objects'''
+
+        created_records = []
+        for record_dict in js['UsageRecords']:
+            record = RecordType()
+            record.set_all(record_dict)
+            created_records.append(record)
+
+        return created_records
+
 
     def _create_jrs(self, msg_text):
         '''

--- a/apel/db/records/__init__.py
+++ b/apel/db/records/__init__.py
@@ -31,6 +31,7 @@ from group_attribute import GroupAttributeRecord
 from job import JobRecord
 from processed import ProcessedRecord
 from accelerator import AcceleratorRecord
+from accelerator_summary import AcceleratorSummary
 
 from storage import StorageRecord
 from summary import SummaryRecord

--- a/apel/db/records/__init__.py
+++ b/apel/db/records/__init__.py
@@ -30,6 +30,7 @@ from event import EventRecord
 from group_attribute import GroupAttributeRecord
 from job import JobRecord
 from processed import ProcessedRecord
+from accelerator import AcceleratorRecord
 
 from storage import StorageRecord
 from summary import SummaryRecord

--- a/apel/db/records/accelerator.py
+++ b/apel/db/records/accelerator.py
@@ -1,0 +1,70 @@
+"""This file contains the AcceleratorRecord class."""
+from apel.common import parse_fqan
+from apel.db.records import Record, InvalidRecordException
+
+
+class AcceleratorRecord(Record):
+    """Class to represent one Accelerator record."""
+    def __init__(self):
+        """Provide the necessary lists containing message information."""
+        Record.__init__(self)
+
+        # This specifies the order of entries to match the database schema
+        self._db_fields = [
+            "MeasurementMonth",
+            "MeasurementYear",
+            "AssociatedRecordType",
+            "AssociatedRecord",
+            "GlobalUserName",
+            "FQAN",
+            "SiteName",
+            "Count",
+            "Cores",
+            "AvailableDuration",
+            "ActiveDuration",
+            "BenchmarkType",
+            "Benchmark",
+            "Type",
+            "Model",
+        ]
+
+        # Fields which are required by the message format.
+        self._mandatory_fields = [
+            "MeasurementMonth",
+            "MeasurementYear",
+            "AssociatedRecordType",
+            "AssociatedRecord",
+            "FQAN",
+            "SiteName",
+            "Count",
+            "AvailableDuration",
+            "Type",
+        ]
+
+        self._int_fields = [
+            "MeasurementMonth",
+            "MeasurementYear",
+            "Cores",
+            "ActiveDuration",
+            "AvailableDuration"
+        ]
+
+        self._float_fields = [
+            "Count",
+            "Benchmark"
+        ]
+
+        # This list specifies the output ordering for printed records
+        self._msg_fields = self._db_fields
+
+        # All allowed fields.
+        self._all_fields = self._db_fields
+
+    def _check_fields(self):
+        """
+        Add extra checks to those made in every record.
+
+        Also populates fields that are extracted from other fields.
+        """
+        # First, call the parent's version.
+        Record._check_fields(self)

--- a/apel/db/records/accelerator.py
+++ b/apel/db/records/accelerator.py
@@ -1,6 +1,22 @@
-"""This file contains the AcceleratorRecord class."""
+"""
+   Copyright (C) 2023 STFC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+"""
+
 from apel.common import parse_fqan
-from apel.db.records import Record, InvalidRecordException
+from apel.db.records import Record
 
 
 class AcceleratorRecord(Record):
@@ -20,8 +36,8 @@ class AcceleratorRecord(Record):
             "SiteName",
             "Count",
             "Cores",
-            "AvailableDuration",
             "ActiveDuration",
+            "AvailableDuration",
             "BenchmarkType",
             "Benchmark",
             "Type",
@@ -46,12 +62,12 @@ class AcceleratorRecord(Record):
             "MeasurementYear",
             "Cores",
             "ActiveDuration",
-            "AvailableDuration"
+            "AvailableDuration",
         ]
 
         self._float_fields = [
             "Count",
-            "Benchmark"
+            "Benchmark",
         ]
 
         # This list specifies the output ordering for printed records
@@ -63,7 +79,6 @@ class AcceleratorRecord(Record):
     def _check_fields(self):
         """
         Add extra checks to those made in every record.
-
         Also populates fields that are extracted from other fields.
         """
         # First, call the parent's version.

--- a/apel/db/records/accelerator_summary.py
+++ b/apel/db/records/accelerator_summary.py
@@ -1,6 +1,22 @@
-"""This file contains the AcceleratorSummary class."""
+"""
+   Copyright (C) 2023 STFC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+"""
+
 from apel.common import parse_fqan
-from apel.db.records import Record, InvalidRecordException
+from apel.db.records import Record
 
 
 class AcceleratorSummary(Record):
@@ -24,7 +40,8 @@ class AcceleratorSummary(Record):
             "Benchmark",
             "Type",
             "Model",
-            "NumberOfRecords"
+            "NumberOfRecords",
+            "PublisherDNID",
         ]
 
         # Fields which are required by the message format.
@@ -44,12 +61,12 @@ class AcceleratorSummary(Record):
             "Cores",
             "ActiveDuration",
             "AvailableDuration",
-            "NumberOfRecords"
+            "NumberOfRecords",
         ]
 
         self._float_fields = [
             "Count",
-            "Benchmark"
+            "Benchmark",
         ]
 
         # This list specifies the output ordering for printed records
@@ -61,7 +78,6 @@ class AcceleratorSummary(Record):
     def _check_fields(self):
         """
         Add extra checks to those made in every record.
-
         Also populates fields that are extracted from other fields.
         """
         # First, call the parent's version.

--- a/apel/db/records/accelerator_summary.py
+++ b/apel/db/records/accelerator_summary.py
@@ -1,0 +1,68 @@
+"""This file contains the AcceleratorSummary class."""
+from apel.common import parse_fqan
+from apel.db.records import Record, InvalidRecordException
+
+
+class AcceleratorSummary(Record):
+    """Class to represent one Accelerator summary record."""
+    def __init__(self):
+        """Provide the necessary lists containing message information."""
+        Record.__init__(self)
+
+        # This specifies the order of entries to match the database schema
+        self._db_fields = [
+            "Month",
+            "Year",
+            "AssociatedRecordType",
+            "GlobalUserName",
+            "SiteName",
+            "Count",
+            "Cores",
+            "AvailableDuration",
+            "ActiveDuration",
+            "BenchmarkType",
+            "Benchmark",
+            "Type",
+            "Model",
+            "NumberOfRecords"
+        ]
+
+        # Fields which are required by the message format.
+        self._mandatory_fields = [
+            "Month",
+            "Year",
+            "AssociatedRecordType",
+            "SiteName",
+            "Count",
+            "AvailableDuration",
+            "Type",
+        ]
+
+        self._int_fields = [
+            "Month",
+            "Year",
+            "Cores",
+            "ActiveDuration",
+            "AvailableDuration",
+            "NumberOfRecords"
+        ]
+
+        self._float_fields = [
+            "Count",
+            "Benchmark"
+        ]
+
+        # This list specifies the output ordering for printed records
+        self._msg_fields = self._db_fields
+
+        # All allowed fields.
+        self._all_fields = self._db_fields
+
+    def _check_fields(self):
+        """
+        Add extra checks to those made in every record.
+
+        Also populates fields that are extracted from other fields.
+        """
+        # First, call the parent's version.
+        Record._check_fields(self)

--- a/apel/db/unloader.py
+++ b/apel/db/unloader.py
@@ -18,10 +18,10 @@
 from apel.db import (Query, ApelDbException, JOB_MSG_HEADER, SUMMARY_MSG_HEADER,
                      NORMALISED_SUMMARY_MSG_HEADER, SYNC_MSG_HEADER,
                      CLOUD_MSG_HEADER, CLOUD_SUMMARY_MSG_HEADER,
-                     ACCELERATOR_MSG_TYPE)
+                     ACCELERATOR_MSG_TYPE, ACCELERATOR_SUMMARY_MSG_TYPE)
 from apel.db.records import (JobRecord, SummaryRecord, NormalisedSummaryRecord,
                              SyncRecord, CloudRecord, CloudSummaryRecord, StorageRecord,
-                             AcceleratorRecord)
+                             AcceleratorRecord, AcceleratorSummary)
 from dirq.QueueSimple import QueueSimple
 try:
     import cStringIO as StringIO
@@ -43,6 +43,7 @@ class DbUnloader(object):
                     CloudRecord: CLOUD_MSG_HEADER,
                     CloudSummaryRecord: CLOUD_SUMMARY_MSG_HEADER,
                     AcceleratorRecord: ACCELERATOR_MSG_TYPE,
+                    AcceleratorSummary: ACCELERATOR_SUMMARY_MSG_TYPE,
                     }
 
     RECORD_TYPES = {'VJobRecords': JobRecord,
@@ -55,6 +56,7 @@ class DbUnloader(object):
                     'VCloudSummaries': CloudSummaryRecord,
                     'VStarRecords': StorageRecord,
                     'AcceleratorRecords': AcceleratorRecord,
+                    'AcceleratorSummaries': AcceleratorSummary,
                     }
 
     # all record types for which withholding DNs is a valid option

--- a/apel/db/unloader.py
+++ b/apel/db/unloader.py
@@ -17,9 +17,11 @@
 '''
 from apel.db import (Query, ApelDbException, JOB_MSG_HEADER, SUMMARY_MSG_HEADER,
                      NORMALISED_SUMMARY_MSG_HEADER, SYNC_MSG_HEADER,
-                     CLOUD_MSG_HEADER, CLOUD_SUMMARY_MSG_HEADER)
+                     CLOUD_MSG_HEADER, CLOUD_SUMMARY_MSG_HEADER,
+                     ACCELERATOR_MSG_TYPE)
 from apel.db.records import (JobRecord, SummaryRecord, NormalisedSummaryRecord,
-                             SyncRecord, CloudRecord, CloudSummaryRecord, StorageRecord)
+                             SyncRecord, CloudRecord, CloudSummaryRecord, StorageRecord,
+                             AcceleratorRecord)
 from dirq.QueueSimple import QueueSimple
 try:
     import cStringIO as StringIO
@@ -39,7 +41,9 @@ class DbUnloader(object):
                     NormalisedSummaryRecord: NORMALISED_SUMMARY_MSG_HEADER,
                     SyncRecord: SYNC_MSG_HEADER,
                     CloudRecord: CLOUD_MSG_HEADER,
-                    CloudSummaryRecord: CLOUD_SUMMARY_MSG_HEADER}
+                    CloudSummaryRecord: CLOUD_SUMMARY_MSG_HEADER,
+                    AcceleratorRecord: ACCELERATOR_MSG_TYPE,
+                    }
 
     RECORD_TYPES = {'VJobRecords': JobRecord,
                     'VSummaries': SummaryRecord,
@@ -49,7 +53,9 @@ class DbUnloader(object):
                     'VSyncRecords': SyncRecord,
                     'VCloudRecords': CloudRecord,
                     'VCloudSummaries': CloudSummaryRecord,
-                    'VStarRecords': StorageRecord}
+                    'VStarRecords': StorageRecord,
+                    'AcceleratorRecords': AcceleratorRecord,
+                    }
 
     # all record types for which withholding DNs is a valid option
     MAY_WITHHOLD_DNS = [JobRecord, SyncRecord, CloudRecord]

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -118,7 +118,6 @@ def runprocess(db_config_file, config_file, log_config_file):
             db.copy_summaries()
         elif db_type == 'cloud':
             db.summarise_cloud()
-        elif db_type == 'accelerator':
             db.summarise_accelerators()
         else:
             raise ApelDbException('Unknown database type: %s' % db_type)

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -118,6 +118,8 @@ def runprocess(db_config_file, config_file, log_config_file):
             db.copy_summaries()
         elif db_type == 'cloud':
             db.summarise_cloud()
+        elif db_type == 'accelerator':
+            db.summarise_accelerators()
         else:
             raise ApelDbException('Unknown database type: %s' % db_type)
 

--- a/conf/unloader.cfg
+++ b/conf/unloader.cfg
@@ -11,6 +11,7 @@ dir_location=/var/spool/apel/
 # VCloudRecords
 # VCloudSummaries
 # VStarRecords
+# AcceleratorSummaries
 table_name = VJobRecords
 
 # Only used when sending job records, job summaries or storage records.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ MySQL-python
 python-ldap
 iso8601
 dirq
+jsonschema

--- a/schemas/accelerator.sql
+++ b/schemas/accelerator.sql
@@ -91,3 +91,119 @@ VALUES(
 END //
 DELIMITER ;
 
+
+DROP TABLE IF EXISTS AcceleratorSummaries;
+CREATE TABLE AcceleratorSummaries (
+    Month INT NOT NULL, 
+    Year INT NOT NULL,
+    AssociatedRecordType VARCHAR(255) NOT NULL,
+    GlobalUserName VARCHAR(255), 
+    SiteName VARCHAR(255) NOT NULL, 
+    Count DECIMAL(10,3) NOT NULL,
+    Cores INT,
+    AvailableDuration INT NOT NULL,
+    ActiveDuration INT,
+    BenchmarkType VARCHAR(255),
+    Benchmark DECIMAL(10,3),
+    Type VARCHAR(255) NOT NULL,
+    Model VARCHAR(255),
+    NumberOfRecords INT NOT NULL,
+    PublisherDN VARCHAR(255) NOT NULL,
+
+    PRIMARY KEY (Month, Year, AssociatedRecordType, SiteName, Type)
+);
+
+
+DROP PROCEDURE IF EXISTS SummariseAccelerators;
+DELIMITER //
+CREATE PROCEDURE SummariseAccelerators()
+
+BEGIN
+    REPLACE INTO AcceleratorSummaries(Month, Year, AssociatedRecordType,
+        GlobalUserName, SiteName, 
+        Cores, Count, AvailableDuration, ActiveDuration, 
+        BenchmarkType, Benchmark, Type, Model, NumberOfRecords, PublisherDN)
+    SELECT 
+      MeasurementMonth, MeasurementYear,
+      AssociatedRecordType,
+      GlobalUserName,
+      SiteName,
+      Count,
+      Cores,
+      SUM(AvailableDuration),
+      SUM(ActiveDuration),
+      BenchmarkType,
+      Benchmark,
+      Type,
+      Model,
+      COUNT(*),
+      'summariser'
+      FROM AcceleratorRecords
+      GROUP BY
+          MeasurementMonth, MeasurementYear, 
+          AssociatedRecordType,
+          GlobalUserName, SiteName,
+          Cores, Type, 
+          Benchmark, BenchmarkType
+      ORDER BY NULL;
+END //
+DELIMITER ;
+
+
+
+DROP PROCEDURE IF EXISTS ReplaceAcceleratorSummaryRecord;
+DELIMITER //
+CREATE PROCEDURE ReplaceAcceleratorSummaryRecord(
+  Month INT,
+  Year INT,
+  associatedRecordType VARCHAR(255),
+  globalUserName VARCHAR(255),
+  siteName VARCHAR(255),
+  count DECIMAL(10,3),
+  cores INT,
+  activeDuration INT,
+  availableDuration INT,
+  benchmarkType VARCHAR(255),
+  benchmark DECIMAL,
+  type VARCHAR(255),
+  model VARCHAR(255),
+  number INT,
+  publisherDN VARCHAR(255)
+)
+BEGIN
+REPLACE INTO AcceleratorSummaries(
+  Month,
+  Year,
+  AssociatedRecordType,
+  GlobalUserName,
+  SiteName,
+  Count,
+  Cores,
+  ActiveDuration,
+  AvailableDuration,
+  BenchmarkType,
+  Benchmark,
+  Type,
+  Model,
+  NumberOfRecords,
+  PublisherDN
+)
+VALUES(
+  Month,
+  Year,
+  associatedRecordType,
+  globalUserName,
+  siteName,
+  count,
+  cores,
+  activeDuration,
+  availableDuration,
+  benchmarkType,
+  benchmark,
+  type,
+  model,
+  number,
+  publisherDN
+);
+END //
+DELIMITER ;

--- a/schemas/accelerator.sql
+++ b/schemas/accelerator.sql
@@ -1,0 +1,93 @@
+-- This schema adds the tables necessary for Accelerator accounting as a
+-- separate record as part of the wider Cloud Accounting system.
+
+DROP TABLE IF EXISTS AcceleratorRecords;
+CREATE TABLE AcceleratorRecords (
+  UpdateTime TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  MeasurementMonth INT NOT NULL,
+  MeasurementYear INT NOT NULL,
+
+  AssociatedRecordType VARCHAR(255) NOT NULL,
+  AssociatedRecord VARCHAR(255) NOT NULL,
+
+  GlobalUserName VARCHAR(255),      
+  FQAN VARCHAR(255) NOT NULL,       
+  SiteName VARCHAR(255) NOT NULL,   
+  Count DECIMAL(10,3) NOT NULL,
+  Cores INT,
+  ActiveDuration INT,
+  AvailableDuration INT,
+  BenchmarkType VARCHAR(255),       
+  Benchmark DECIMAL(10,3),                
+  Type VARCHAR(255) NOT NULL,       
+  Model VARCHAR(255),               
+  PublisherDNID INT NOT NULL,
+
+  PRIMARY KEY (MeasurementMonth, MeasurementYear, 
+               AssociatedRecordType, AssociatedRecord, 
+               SiteName)
+
+  -- [?] INDEX
+
+);
+
+DROP PROCEDURE IF EXISTS ReplaceAcceleratorRecord;
+DELIMITER //
+CREATE PROCEDURE ReplaceAcceleratorRecord(
+  measurementMonth INT,
+  measurementYear INT,
+  associatedRecordType VARCHAR(255),
+  associatedRecord VARCHAR(255),
+  globalUserName VARCHAR(255),
+  fqan VARCHAR(255),
+  siteName VARCHAR(255),
+  count DECIMAL(10,3),
+  cores INT,
+  activeDuration INT,
+  availableDuration INT,
+  benchmarkType VARCHAR(255),
+  benchmark DECIMAL,
+  type VARCHAR(255),
+  model VARCHAR(255),
+  publisherDN VARCHAR(255)
+)
+BEGIN
+REPLACE INTO AcceleratorRecords(
+  MeasurementMonth,
+  MeasurementYear,
+  AssociatedRecordType,
+  AssociatedRecord,
+  GlobalUserName,
+  FQAN,
+  SiteName,
+  Count,
+  Cores,
+  ActiveDuration,
+  AvailableDuration,
+  BenchmarkType,
+  Benchmark,
+  Type,
+  Model,
+  PublisherDNID
+)
+VALUES(
+  measurementMonth,
+  measurementYear,
+  associatedRecordType,
+  associatedRecord,
+  globalUserName,
+  fqan,
+  siteName,
+  count,
+  cores,
+  activeDuration,
+  availableDuration,
+  benchmarkType,
+  benchmark,
+  type,
+  model,
+  DNLookup(publisherDN)
+);
+END //
+DELIMITER ;
+

--- a/test/test_accelerator_record.py
+++ b/test/test_accelerator_record.py
@@ -6,28 +6,28 @@ from apel.db.records import AcceleratorRecord
 
 
 class AcceleratorRecordTest(unittest.TestCase):
-    '''
+    """
     Test case for AcceleratorRecord
-    '''
+    """
 
     def setUp(self):
         self._msg1 = '''
-MeasurementMonth: 12
-MeasurementYear: 2021
-AssociatedRecordType: cloud
-AssociatedRecord: UUIDx
-GlobalUserName: /C=UK/O=eScience/OU=CLRC/L=RAL/CN=apel-consumer2.esc.rl.ac.uk/emailAddress=sct-certificates@stfc.ac.uk
-FQAN: fqan1
-SiteName: Site Navigation
-Count: 604800.000
-Cores: 857
-AvailableDuration: 326057
-ActiveDuration: 30739
-BenchmarkType: Site FAQs
-Benchmark: 326.000
-Type: Accelerator
-Model: HS About
-'''
+                MeasurementMonth: 12
+                MeasurementYear: 2021
+                AssociatedRecordType: cloud
+                AssociatedRecord: UUIDx
+                GlobalUserName: /C=UK/O=eScience/OU=CLRC/L=RAL/CN=apel-consumer2.esc.rl.ac.uk/emailAddress=sct-certificates@stfc.ac.uk
+                FQAN: fqan1
+                SiteName: Site Navigation
+                Count: 604800.000
+                Cores: 857
+                AvailableDuration: 326057
+                ActiveDuration: 30739
+                BenchmarkType: Site FAQs
+                Benchmark: 326.000
+                Type: Accelerator
+                Model: HS About
+                '''
 
         self._values1 = {
                 'MeasurementMonth': 12,
@@ -81,7 +81,3 @@ Model: HS About
 
 if __name__ == '__main__':
     unittest.main()
-
-
-
-

--- a/test/test_accelerator_record.py
+++ b/test/test_accelerator_record.py
@@ -1,0 +1,87 @@
+#!/bin/env python2.7
+
+import unittest
+
+from apel.db.records import AcceleratorRecord
+
+
+class AcceleratorRecordTest(unittest.TestCase):
+    '''
+    Test case for AcceleratorRecord
+    '''
+
+    def setUp(self):
+        self._msg1 = '''
+MeasurementMonth: 12
+MeasurementYear: 2021
+AssociatedRecordType: cloud
+AssociatedRecord: UUIDx
+GlobalUserName: /C=UK/O=eScience/OU=CLRC/L=RAL/CN=apel-consumer2.esc.rl.ac.uk/emailAddress=sct-certificates@stfc.ac.uk
+FQAN: fqan1
+SiteName: Site Navigation
+Count: 604800.000
+Cores: 857
+AvailableDuration: 326057
+ActiveDuration: 30739
+BenchmarkType: Site FAQs
+Benchmark: 326.000
+Type: Accelerator
+Model: HS About
+'''
+
+        self._values1 = {
+                'MeasurementMonth': 12,
+                'MeasurementYear': 2021,
+                'AssociatedRecordType': 'cloud',
+                'AssociatedRecord': 'UUIDx',
+                'GlobalUserName': '/C=UK/O=eScience/OU=CLRC/L=RAL/CN=apel-consumer2.esc.rl.ac.uk/emailAddress=sct-certificates@stfc.ac.uk',
+                'FQAN': 'fqan1',
+                'SiteName': 'Site Navigation',
+                'Count': 604800.000,
+                'Cores': 857,
+                'AvailableDuration': 326057,
+                'ActiveDuration': 30739,
+                'BenchmarkType': 'Site FAQs',
+                'Benchmark': 326.000,
+                'Type': 'Accelerator',
+                'Model': 'HS About',
+        }
+
+        self.cases = {}
+        self.cases[self._msg1] = self._values1
+
+    def test_load_from_msg(self):
+
+        for msg in self.cases.keys():
+
+            acceleratorr = AcceleratorRecord()
+            acceleratorr.load_from_msg(msg)
+
+            cont = acceleratorr._record_content
+
+            for key in self.cases[msg].keys():
+                self.assertEqual(cont[key], self.cases[msg][key], "%s != %s for key %s" % (cont[key], self.cases[msg][key], key))
+
+    def test_mandatory_fields(self):
+        record = AcceleratorRecord()
+        record.set_field('SiteName', 'MySite')
+        record.set_field("MeasurementMonth", '01')
+        record.set_field("MeasurementYear", '2021')
+        record.set_field("AssociatedRecordType", 'cloud')
+        record.set_field("AssociatedRecord", 'UUIDx')
+        record.set_field("FQAN", 'fqan2')
+        record.set_field("Count", 100.01)
+        record.set_field("AvailableDuration", 1000)
+        record.set_field("Type", 'Accelerator')
+
+        try:
+            record._check_fields()
+        except Exception as e:
+            self.fail('_check_fields method failed: %s [%s]' % (e, type(e)))
+
+if __name__ == '__main__':
+    unittest.main()
+
+
+
+

--- a/test/test_accelerator_summary.py
+++ b/test/test_accelerator_summary.py
@@ -1,0 +1,85 @@
+#!/bin/env python2.7
+
+import unittest
+
+from apel.db.records import AcceleratorSummary
+
+
+class AcceleratorSummaryRecordTest(unittest.TestCase):
+    '''
+    Test case for AcceleratorSummary
+    '''
+
+    def setUp(self):
+        self._msg1 = '''
+Month: 12
+Year: 2021
+AssociatedRecordType: cloud
+GlobalUserName: /C=UK/O=eScience/OU=CLRC/L=RAL/CN=apel-consumer2.esc.rl.ac.uk/emailAddress=sct-certificates@stfc.ac.uk
+SiteName: Site Navigation
+Count: 604800.000
+Cores: 857
+AvailableDuration: 326057
+ActiveDuration: 30739
+BenchmarkType: Site FAQs
+Benchmark: 326.000
+Model: HS About
+Type: Accelerator
+NumberOfRecords: 1000
+'''
+
+
+        self._values1 = {
+                'Month': 12,
+                'Year': 2021,
+                'AssociatedRecordType': 'cloud',
+                'GlobalUserName': '/C=UK/O=eScience/OU=CLRC/L=RAL/CN=apel-consumer2.esc.rl.ac.uk/emailAddress=sct-certificates@stfc.ac.uk',
+                'SiteName': 'Site Navigation',
+                'Count': 604800.000,
+                'Cores': 857,
+                'AvailableDuration': 326057,
+                'ActiveDuration': 30739,
+                'BenchmarkType': 'Site FAQs',
+                'Benchmark': 326.000,
+                'Model': 'HS About',
+                'Type': 'Accelerator',
+                'NumberOfRecords': 1000,
+        }
+
+        self.cases = {}
+        self.cases[self._msg1] = self._values1
+
+    def test_load_from_msg(self):
+
+        for msg in self.cases.keys():
+
+            acceleratorr = AcceleratorSummary()
+            acceleratorr.load_from_msg(msg)
+
+            cont = acceleratorr._record_content
+
+            for key in self.cases[msg].keys():
+                self.assertEqual(cont[key], self.cases[msg][key], "%s != %s for key %s" % (cont[key], self.cases[msg][key], key))
+
+    def test_mandatory_fields(self):
+        record = AcceleratorSummary()
+        record.set_field("Month", '01')
+        record.set_field("Year", '2021')
+        record.set_field("AssociatedRecordType", 'cloud')
+        record.set_field('SiteName', 'MySite')
+        record.set_field("Count", 100.01)
+        record.set_field("AvailableDuration", 1000)
+        record.set_field("Type", 'Accelerator')
+        record.set_field("NumberOfRecords", 10)
+
+        try:
+            record._check_fields()
+        except Exception as e:
+            self.fail('_check_fields method failed: %s [%s]' % (e, type(e)))
+
+if __name__ == '__main__':
+    unittest.main()
+
+
+
+

--- a/test/test_accelerator_summary.py
+++ b/test/test_accelerator_summary.py
@@ -79,7 +79,3 @@ NumberOfRecords: 1000
 
 if __name__ == '__main__':
     unittest.main()
-
-
-
-

--- a/test/test_accelerator_summary.py
+++ b/test/test_accelerator_summary.py
@@ -6,28 +6,27 @@ from apel.db.records import AcceleratorSummary
 
 
 class AcceleratorSummaryRecordTest(unittest.TestCase):
-    '''
+    """
     Test case for AcceleratorSummary
-    '''
+    """
 
     def setUp(self):
         self._msg1 = '''
-Month: 12
-Year: 2021
-AssociatedRecordType: cloud
-GlobalUserName: /C=UK/O=eScience/OU=CLRC/L=RAL/CN=apel-consumer2.esc.rl.ac.uk/emailAddress=sct-certificates@stfc.ac.uk
-SiteName: Site Navigation
-Count: 604800.000
-Cores: 857
-AvailableDuration: 326057
-ActiveDuration: 30739
-BenchmarkType: Site FAQs
-Benchmark: 326.000
-Model: HS About
-Type: Accelerator
-NumberOfRecords: 1000
-'''
-
+                Month: 12
+                Year: 2021
+                AssociatedRecordType: cloud
+                GlobalUserName: /C=UK/O=eScience/OU=CLRC/L=RAL/CN=apel-consumer2.esc.rl.ac.uk/emailAddress=sct-certificates@stfc.ac.uk
+                SiteName: Site Navigation
+                Count: 604800.000
+                Cores: 857
+                AvailableDuration: 326057
+                ActiveDuration: 30739
+                BenchmarkType: Site FAQs
+                Benchmark: 326.000
+                Model: HS About
+                Type: Accelerator
+                NumberOfRecords: 1000
+                '''
 
         self._values1 = {
                 'Month': 12,
@@ -50,7 +49,6 @@ NumberOfRecords: 1000
         self.cases[self._msg1] = self._values1
 
     def test_load_from_msg(self):
-
         for msg in self.cases.keys():
 
             acceleratorr = AcceleratorSummary()

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -181,7 +181,8 @@ class LoaderTest(unittest.TestCase):
                         [call('Message contains %i records', 1)])
 
     def test_load_json_type(self):
-        """Check that load_records is called and message is logged correctly for json messages."""
+        """Check that load_records is called and message is
+            logged correctly for json messages."""
 
         from apel.common import json_utils
 

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -180,6 +180,68 @@ class LoaderTest(unittest.TestCase):
             mock_log.assert_has_calls(
                         [call('Message contains %i records', 1)])
 
+    def test_load_json_type(self):
+        """Check that load_records is called and message is logged correctly for json messages."""
+
+        from apel.common import json_utils
+
+        logger = logging.getLogger('loader')
+        pidfile = os.path.join(self.dir_path, 'pidfile')
+
+        in_q = dirq.queue.Queue(os.path.join(self.dir_path, 'incoming'),
+                                schema=schema)
+
+        record0 = {
+            "MeasurementMonth": 9,
+            "MeasurementYear": 2018,
+            "AssociatedRecordType": "cloud",
+            "AssociatedRecord": "TEST-FakeVMUUID",
+            "GlobalUserName": "GlobalUser1",
+            "FQAN": "FQAN1",
+            "SiteName": "TEST-SITE",
+            "Count": 0.5,
+            "Cores": 64,
+            "ActiveDuration": 600,
+            "AvailableDuration": 6000,
+            "BenchmarkType": "BenchmarkType1",
+            "Benchmark": 1005,
+            "Type": "GPU",
+            "Model": "Model1",
+        }
+
+        record1 = {
+            "MeasurementMonth": 9,
+            "MeasurementYear": 2018,
+            "AssociatedRecordType": "cloud",
+            "AssociatedRecord": "TEST-FakeVMUUID2",
+            "GlobalUserName": "GlobalUser2",
+            "FQAN": "FQAN2",
+            "SiteName": "TEST-SITE",
+            "Count": 1,
+            "Cores": 8,
+            "ActiveDuration": 30,
+            "AvailableDuration": 600,
+            "BenchmarkType": "BenchmarkType2",
+            "Benchmark": 995,
+            "Type": "FPGA",
+            "Model": "Model2",
+        }
+
+        json_msg = json_utils.to_message("APEL-Accelerator-message", "0.1", record0, record1)
+
+        in_q.add({"body": json_msg, "signer": "test signer", "empaid": "", "error": ""})
+
+        self.loader = apel.db.loader.Loader(self.dir_path, True, 'mysql',
+                                            'host', 1234, 'db', 'user', 'pwd',
+                                            pidfile)
+
+        with mock.patch.object(logger, 'info') as mock_log:
+            self.loader.load_all_msgs()
+            self.mock_db.load_records.assert_called_once()
+            mock_log.assert_has_calls(
+                        [call('Message contains %i %s records', 2, 'Accelerator')])
+
+
     def tearDown(self):
         shutil.rmtree(self.dir_path)
         mock.patch.stopall()

--- a/test/test_record_factory.py
+++ b/test/test_record_factory.py
@@ -5,12 +5,14 @@ Created on 4 Jul 2011
 
 Tests for the RecordFactory.
 '''
+from datetime import datetime
 import unittest
 
 from apel.db.loader.record_factory import RecordFactory, RecordFactoryException
 from apel.db.records import (CloudRecord, CloudSummaryRecord, JobRecord,
                              NormalisedSummaryRecord, StorageRecord,
                              SummaryRecord, SyncRecord)
+from apel.common.json_utils import JSON_MSG_BOILERPLATE
 
 
 class TestRecordFactory(unittest.TestCase):
@@ -93,6 +95,111 @@ class TestRecordFactory(unittest.TestCase):
         """Check that creating a cloud summary returns a CloudSummaryRecord."""
         records = self._rf.create_records(self._csr_text)
         self.assertTrue(isinstance(records[0], CloudSummaryRecord))
+
+    def test_create_records_json_malformed(self):
+        """Test the expected error is raised on handling malformed JSON."""
+        malformed_json = '{"Key": "Value}'
+
+        with self.assertRaisesRegexp(RecordFactoryException,
+                                     "^Malformed JSON:"):
+            self._rf.create_records(malformed_json)
+
+    def test_create_records_json_unknown_type(self):
+        """Test the expected error is raised on messages without a type."""
+        unknown_type_json = '{"Key": "Value"}'
+
+        with self.assertRaisesRegexp(RecordFactoryException, 
+                                     "^Type of JSON message not provided."):
+            self._rf.create_records(unknown_type_json)
+
+    def test_create_records_json_unsupported_type(self):
+        """Test the expected error is raised on unsupported message types."""
+        unsupported_json = self._generate_json_message(
+            "Spammy Type", "ignored version", "[{'Key': 'Value'}]"
+        )
+
+        with self.assertRaisesRegexp(RecordFactoryException,
+                                     "^Unsupported JSON message type:"):
+            self._rf.create_records(unsupported_json)
+
+    def test_create_records_accelerator(self):
+        """Test creation of AcceleratorRecords from a JSON message."""
+        # Create some records for a test message.
+        record0 = {
+            "MeasurementMonth": 9,
+            "MeasurementYear": 2018,
+            "AssociatedRecordType": "cloud",
+            "AssociatedRecord": "TEST-FakeVMUUID",
+            "GlobalUserName": "GlobalUser1",
+            "FQAN": "FQAN1",
+            "SiteName": "TEST-SITE",
+            "Count": 0.5,
+            "Cores": 64,
+            "ActiveDuration": 600,
+            "AvailableDuration": 6000,
+            "BenchmarkType": "BenchmarkType1",
+            "Benchmark": 1005,
+            "Type": "GPU",
+            "Model": "Model1",
+        }
+
+        record1 = {
+            "MeasurementMonth": 9,
+            "MeasurementYear": 2018,
+            "AssociatedRecordType": "cloud",
+            "AssociatedRecord": "TEST-FakeVMUUID2",
+            "GlobalUserName": "GlobalUser2",
+            "FQAN": "FQAN2",
+            "SiteName": "TEST-SITE",
+            "Count": 1,
+            "Cores": 8,
+            "ActiveDuration": 30,
+            "AvailableDuration": 600,
+            "BenchmarkType": "BenchmarkType2",
+            "Benchmark": 995,
+            "Type": "FPGA",
+            "Model": "Model2",
+        }
+
+        # Create a list of records and build a Accelerator accounting message.
+        usage_records = [record0, record1]
+        accelerator_accounting_message_v00 = self._generate_json_message(
+            "APEL-Accelerator-message", "0.1", usage_records
+        )
+
+        # Create the record objects, using the RecordFactory.
+        record_object_list = self._rf.create_records(accelerator_accounting_message_v00)
+
+        # Compare the generated record objects with the dictionary provided
+        # as input.
+        self._compare_record_to_dictionary(record_object_list[0], record0)
+        self._compare_record_to_dictionary(record_object_list[1], record1)
+
+    def _generate_json_message(self, type, version, usage_records):
+        """Helper function to generate JSON messages."""
+        message = JSON_MSG_BOILERPLATE % (type, version, usage_records)
+        # The above will put single quotes into the created message, but
+        # JSON is strictly double quotes. So replace single quotes.
+        message = message.replace("'", '"')
+        return message
+
+    def _compare_record_to_dictionary(self, record_object, dictionary):
+        """Helper function to compare a record object and a dictionary."""
+        # Loop through the record content of the record object.
+        for key, value in record_object._record_content.items():
+            # Compare the value in the record object to the corresponding key
+            # in the dictionary. Handle datetime fields differently because in
+            # the message they are expressed as seconds-since-epoch, but in the
+            # object they are datetime objects.
+            if key in record_object._datetime_fields:
+                self.assertEqual(
+                    value,
+                    datetime.utcfromtimestamp(dictionary[key])
+                )
+            # This test fails when the local clock uses daylight savings time.
+            else:
+                self.assertEqual(value, dictionary[key])
+
 
     def _get_msg_text(self):
     # Below, I've just got some test data hard-coded.
@@ -200,7 +307,6 @@ Year: 2011
 NumberOfVMs: 1
 %%
 '''
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_record_factory.py
+++ b/test/test_record_factory.py
@@ -100,15 +100,14 @@ class TestRecordFactory(unittest.TestCase):
         """Test the expected error is raised on handling malformed JSON."""
         malformed_json = '{"Key": "Value}'
 
-        with self.assertRaisesRegexp(RecordFactoryException,
-                                     "^Malformed JSON:"):
+        with self.assertRaisesRegexp(RecordFactoryException, "^Malformed JSON:"):
             self._rf.create_records(malformed_json)
 
     def test_create_records_json_unknown_type(self):
         """Test the expected error is raised on messages without a type."""
         unknown_type_json = '{"Key": "Value"}'
 
-        with self.assertRaisesRegexp(RecordFactoryException, 
+        with self.assertRaisesRegexp(RecordFactoryException,
                                      "^Type of JSON message not provided."):
             self._rf.create_records(unknown_type_json)
 


### PR DESCRIPTION
Minor changes to #264 . Once summarizes the accelerator records and user performs unloading.
The output would be:
```

APEL-Accelerator-summary-message
Month: 9
Year: 2023
AssociatedRecordType: cloud
GlobalUserName: RALUserA
SiteName: RAL-SITE
Count: 1.4
Cores: 128
AvailableDuration: 4000
ActiveDuration: None
BenchmarkType: HEPSPEC
Benchmark: 9000.0
Type: GPU
Model: ModelA
NumberOfRecords: 1
PublisherDNID: summariser
%%
```