### PR TITLE
[#238] Add storage record type for logger

### DIFF
--- a/apel/db/loader/loader.py
+++ b/apel/db/loader/loader.py
@@ -204,7 +204,9 @@ class Loader(object):
                     apel.db.records.sync.SyncRecord: 'Sync',
                     apel.db.records.cloud.CloudRecord: 'Cloud',
                     apel.db.records.cloud_summary.CloudSummaryRecord:
-                    'Cloud Summary'}
+                    'Cloud Summary',
+                    apel.db.records.storage.StorageRecord: 'Storage',
+                    }
 
         log.info('Loading message from %s', signer)
 

--- a/apel/db/loader/loader.py
+++ b/apel/db/loader/loader.py
@@ -197,16 +197,14 @@ class Loader(object):
         from its text content into the database.
         '''
         record_types = {
-                    apel.db.records.summary.SummaryRecord: 'Summary',
-                    apel.db.records.job.JobRecord: 'Job',
-                    apel.db.records.normalised_summary.NormalisedSummaryRecord:
-                    'Normalised Summary',
-                    apel.db.records.sync.SyncRecord: 'Sync',
-                    apel.db.records.cloud.CloudRecord: 'Cloud',
-                    apel.db.records.cloud_summary.CloudSummaryRecord:
-                    'Cloud Summary',
-                    apel.db.records.storage.StorageRecord: 'Storage',
-                    }
+            apel.db.records.summary.SummaryRecord: 'Summary',
+            apel.db.records.job.JobRecord: 'Job',
+            apel.db.records.normalised_summary.NormalisedSummaryRecord: 'Normalised Summary',
+            apel.db.records.sync.SyncRecord: 'Sync',
+            apel.db.records.cloud.CloudRecord: 'Cloud',
+            apel.db.records.cloud_summary.CloudSummaryRecord: 'Cloud Summary',
+            apel.db.records.storage.StorageRecord: 'Storage',
+        }
 
         log.info('Loading message from %s', signer)
 

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -143,8 +143,9 @@ class LoaderTest(unittest.TestCase):
             mock_log.assert_has_calls(
                         [call('Message contains 1 %s record', 'Summary')])
 
-    def test_load_all_other_type(self):
-        """Check that load_records is called and message is logged correctly when type is other"""
+    def test_load_all_storage_type(self):
+        """Check that load_records is called and message is logged
+            correctly when record type is storage"""
         logger = logging.getLogger('loader')
         pidfile = os.path.join(self.dir_path, 'pidfile')
 

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -178,7 +178,7 @@ class LoaderTest(unittest.TestCase):
             self.loader.load_all_msgs()
             self.mock_db.load_records.assert_called_once()
             mock_log.assert_has_calls(
-                        [call('Message contains %i records', 1)])
+                        [call('Message contains 1 %s record', 'Storage')])
 
     def tearDown(self):
         shutil.rmtree(self.dir_path)

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -144,8 +144,10 @@ class LoaderTest(unittest.TestCase):
                         [call('Message contains 1 %s record', 'Summary')])
 
     def test_load_all_storage_type(self):
-        """Check that load_records is called and message is logged
-            correctly when record type is storage"""
+        """Check that load_records calls and logs with storage records.
+
+        This checks that load_records is called and the message is logged
+        correctly when the record type is storage."""
         logger = logging.getLogger('loader')
         pidfile = os.path.join(self.dir_path, 'pidfile')
 


### PR DESCRIPTION
When user sends storage record starting with '<'. Previously it doesn't have the class type in `record_type`. Now it should say Storage if it is a storage record when it receives a file from receiver.

Resolves #238 