### PR TITLE
Fix HTCondor format for trailing empty fields

### DIFF
--- a/apel/parsers/htcondor.py
+++ b/apel/parsers/htcondor.py
@@ -39,7 +39,7 @@ class HTCondorParser(Parser):
         Parses single line from accounting log file.
         '''
         # condor_history -constraint "JobStartDate > 0" -format "%s|" GlobalJobId -format "%s|" Owner -format "%d|" RemoteWallClockTime -format "%d|" RemoteUserCpu -format "%d|" RemoteSysCpu -format "%d|" JobStartDate -format "%d|" EnteredCurrentStatus -format "%d|" ResidentSetSize_RAW -format "%d|" ImageSize_RAW -format "%d|\n" RequestCpus
-        # arcce.rl.ac.uk#2376.0#71589|tatls011|287|107|11|1435671643|1435671930|26636|26832|1|1
+        # arcce.rl.ac.uk#2376.0#71589|tatls011|287|107|11|1435671643|1435671930|26636|26832|1|1|
 
         values = line.strip().split('|')
 

--- a/apel/parsers/htcondor.py
+++ b/apel/parsers/htcondor.py
@@ -45,7 +45,7 @@ class HTCondorParser(Parser):
 
         # Set scaling factor using value from log if appended to log line.
         cputmult = float(1.0)
-        if len(values) > 10:
+        if len(values) > 10 and values[10]:
             cputmult = float(values[10])
 
         mapping = {'Site'            : lambda x: self.site_name,

--- a/apel/parsers/htcondor.py
+++ b/apel/parsers/htcondor.py
@@ -38,7 +38,7 @@ class HTCondorParser(Parser):
         '''
         Parses single line from accounting log file.
         '''
-        # condor_history -constraint "JobStartDate > 0" -format "%s|" GlobalJobId -format "%s|" Owner -format "%d|" RemoteWallClockTime -format "%d|" RemoteUserCpu -format "%d|" RemoteSysCpu -format "%d|" JobStartDate -format "%d|" EnteredCurrentStatus -format "%d|" ResidentSetSize_RAW -format "%d|" ImageSize_RAW -format "%d|" RequestCpus
+        # condor_history -constraint "JobStartDate > 0" -format "%s|" GlobalJobId -format "%s|" Owner -format "%d|" RemoteWallClockTime -format "%d|" RemoteUserCpu -format "%d|" RemoteSysCpu -format "%d|" JobStartDate -format "%d|" EnteredCurrentStatus -format "%d|" ResidentSetSize_RAW -format "%d|" ImageSize_RAW -format "%d|\n" RequestCpus
         # arcce.rl.ac.uk#2376.0#71589|tatls011|287|107|11|1435671643|1435671930|26636|26832|1|1
 
         values = line.strip().split('|')

--- a/test/test_htcondor_parser.py
+++ b/test/test_htcondor_parser.py
@@ -32,6 +32,8 @@ class HTCondorParserTest(unittest.TestCase):
             'arcce.rl.ac.uk#2376.0#1589|tatls011|287|107|11|1435671643|1435671930|26636|26832|1|1',
             'arcce.rl.ac.uk#2486.0#1888|t2k016|4|0|0|1435671919|1435671922|0|11|1|1',
             'arcce.rl.ac.uk#2478.0#1874|snoplus014|2|0|0|1435671918|1435671920|0|11|1|1',
+            # No scale factor and trailing pipe symbol (possible output from HTCondor-CE)
+            'arcce.rl.ac.uk#2376.0#71589|tatls011|287|107|11|1435671643|1435671930|26636|26832|1|',
         )
 
         values = (
@@ -51,6 +53,10 @@ class HTCondorParserTest(unittest.TestCase):
              datetime.datetime(2015, 6, 30, 13, 45, 18),
              datetime.datetime(2015, 6, 30, 13, 45, 20),
              0, 11, 0, 1),
+            ('arcce.rl.ac.uk#2376.0#71589', 'tatls011', None, 287, 118,
+             datetime.datetime(2015, 6, 30, 13, 40, 43),
+             datetime.datetime(2015, 6, 30, 13, 45, 30),
+             26636, 26832, 0, 1),
         )
 
         cases = {}


### PR DESCRIPTION
This PR adjusts the `htcondor` parser to match its own example and HTCondor-CE. It is still compatible with the old format.

- HTCondor parser now ignores a trailing, *empty* field after all required ones. This means the final `|` can act both as a delimiter and terminator.
- The example is adjusted for consistency: The query now has a newline to make it feasible for multiple jobs, and the output has the trailing `|` of the query.

Closes #341.