### PR TITLE
Update and simplify upload-artifact action version

### DIFF
--- a/.github/workflows/build-pkgs.yml
+++ b/.github/workflows/build-pkgs.yml
@@ -48,7 +48,7 @@ jobs:
       run: rpmlint ${{ steps.rpm.outputs.rpm_dir_path }}
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4.2.0
+      uses: actions/upload-artifact@v4.3
       with:
         name: Binary and Source RPMs
         path: |


### PR DESCRIPTION
Setting the version to just major.minor rather than major.minor.patch and letting the Action pull in the latest of the minor series should hopefully reduce the number of dependabot PRs a little while still giving us a good view on relevant changes.

Inspired by https://github.com/GOCDB/gocdb-failover-scripts/pull/30

And reminded by: https://github.com/apel/apel/pull/349