### PR TITLE
Replace optparse with argparse

### DIFF
--- a/bin/client.py
+++ b/bin/client.py
@@ -30,11 +30,12 @@ from future import standard_library
 standard_library.install_aliases()
 from future.builtins import str
 
-from optparse import OptionParser
 import sys
 import os
 import logging.config
 import ldap
+from argparse import ArgumentParser
+
 try:
     # Renamed ConfigParser to configparser in Python 3
     import configparser as ConfigParser
@@ -281,31 +282,36 @@ def main():
     '''
     install_exc_handler(default_handler)
     ver = 'APEL client %s.%s.%s' % __version__
-    opt_parser = OptionParser(version=ver, description=__doc__)
 
-    opt_parser.add_option('-c', '--config',
-                          help='main configuration file for APEL',
-                          default='/etc/apel/client.cfg')
+    default_conf_location = '/etc/apel/client.cfg'
+    default_ssm_conf_location = '/etc/apel/sender.cfg'
+    arg_parser = ArgumentParser(description=__doc__)
 
-    opt_parser.add_option('-s', '--ssm_config',
-                          help='location of SSM config file',
-                          default='/etc/apel/sender.cfg')
+    arg_parser.add_argument('-c', '--config',
+                            help='Location of main configuration file for APEL',
+                            default=default_conf_location)
+    arg_parser.add_argument('-s', '--ssm_config',
+                            help='Location of SSM config file',
+                            default=default_ssm_conf_location)
+    arg_parser.add_argument('-l', '--log_config',
+                            help='DEPRECATED - Location of logging config file (optional)',
+                            default=None)
+    arg_parser.add_argument('-v', '--version',
+                            action='version',
+                            version=ver)
 
-    opt_parser.add_option('-l', '--log_config',
-                          help='DEPRECATED - location of logging config file',
-                          default=None)
-
-    options, unused_args = opt_parser.parse_args()
+    # Using the vars function to output a dict-like view rather than Namespace object.
+    options = vars(arg_parser.parse_args())
 
     # Deprecating functionality.
-    if os.path.exists('/etc/apel/logging.cfg') or options.log_config is not None:
+    if os.path.exists('/etc/apel/logging.cfg') or options['log_config'] is not None:
         logging.warning('Separate logging config file option has been deprecated.')
 
     ccp = ConfigParser.ConfigParser()
-    ccp.read(options.config)
+    ccp.read(options['config'])
 
     scp = ConfigParser.ConfigParser()
-    scp.read(options.ssm_config)
+    scp.read(options['ssm_config'])
 
     # set up logging
     try:

--- a/bin/dbloader.py
+++ b/bin/dbloader.py
@@ -37,6 +37,7 @@ from daemon.daemon import DaemonContext
 from apel.db.loader import Loader, LoaderException
 from apel.common import set_up_logging
 from apel import __version__
+from argparse import ArgumentParser
 from optparse import OptionParser
 
 
@@ -132,19 +133,30 @@ def run_as_daemon(loader, interval):
 
 
 if __name__ == '__main__':
-    ver = "Starting APEL dbloader %s.%s.%s" % __version__
-    opt_parser = OptionParser(version=ver)
-    opt_parser.add_option('-d', '--db', help='location of DB config file',
-                          default='/etc/apel/db.cfg')
-    opt_parser.add_option('-c', '--config', help='Location of config file',
-                          default='/etc/apel/loader.cfg')
-    opt_parser.add_option('-l', '--log_config', help='DEPRECATED - location of logging config file',
-                          default=None)
 
-    options, args = opt_parser.parse_args()
+    ver = "Starting APEL dbloader %s.%s.%s" % __version__
+    default_db_conf_location = '/etc/apel/db.cfg'
+    default_conf_location = '/etc/apl/loader.cfg'
+    arg_parser = ArgumentParser()
+
+    arg_parser.add_argument('-d', '--db',
+                            help='Location of DB',
+                            default=default_db_conf_location)
+    arg_parser.add_argument('-c', '--config',
+                            help="Location of config file",
+                            default=default_conf_location)
+    arg_parser.add_argument('-l', '--log_config',
+                            help='DEPRECATED - Location of logging config file (optional)',
+                            default=None)
+    arg_parser.add_argument('-v', '--version',
+                            action='version',
+                            version=ver)
+
+    # Using the vars function to output a dict-like view rather than Namespace object.
+    options = arg_parser.parse_args()
 
     # Deprecating functionality.
-    if os.path.exists('/etc/apel/logging.cfg') or options.log_config is not None:
+    if os.path.exists('/etc/apel/logging.cfg') or options['log_config'] is not None:
         logging.warning('Separate logging config file option has been deprecated.')
 
-    runprocess(options.db, options.config)
+    runprocess(options['db'], options['config'])

--- a/bin/dbunloader.py
+++ b/bin/dbunloader.py
@@ -21,13 +21,13 @@ from __future__ import print_function
 from future import standard_library
 standard_library.install_aliases()
 
+from argparse import ArgumentParser
 try:
     # Renamed ConfigParser to configparser in Python 3
     import configparser as ConfigParser
 except ImportError:
     import ConfigParser
 import logging.config
-from optparse import OptionParser
 import os
 import sys
 
@@ -35,7 +35,6 @@ from apel import __version__
 from apel.common import set_up_logging
 from apel.db import ApelDb, ApelDbException
 from apel.db.unloader import DbUnloader
-
 
 RECORDS_PER_MESSAGE_MIN = 1
 RECORDS_PER_MESSAGE_DEFAULT = 1000
@@ -77,23 +76,35 @@ def _bounded_records_per_message(config_object, logger):
 
 
 if __name__ == '__main__':
-    opt_parser = OptionParser()
-    opt_parser.add_option('-d', '--db', help='location of configuration file for database',
-                          default='/etc/apel/db.cfg')
-    opt_parser.add_option('-c', '--config', help='Location of configuration file for dbunloader',
-                          default='/etc/apel/unloader.cfg')
-    opt_parser.add_option('-l', '--log_config', help='DEPRECATED - location of logging config file',
-                          default=None)
 
-    options, args = opt_parser.parse_args()
+    ver = 'Starting APEL dbunloader %s.%s.%s' % __version__
+    default_db_conf_location = '/etc/apel/db.cfg'
+    default_dbun_conf_location = '/etc/apel/unloader.cfg'
+    arg_parser = ArgumentParser()
+
+    arg_parser.add_argument('-d', '--db',
+                            help='Location of config file for database',
+                            default=default_db_conf_location)
+    arg_parser.add_argument('-c', '--config',
+                            help='Location of config file for dbunloader',
+                            default=default_dbun_conf_location)
+    arg_parser.add_argument('-l', '--log_config',
+                            help='DEPRECATED - Location of logging config file for dbloader',
+                            default=None)
+    arg_parser.add_argument('-v', '--version',
+                            action='version',
+                            version=ver)
+
+    # Using the vars function to output a dict-like view rather than Namespace object.
+    options = vars(arg_parser.parse_args())
 
     # Deprecating functionality.
-    if os.path.exists('/etc/apel/logging.cfg') or options.log_config is not None:
+    if os.path.exists('/etc/apel/logging.cfg') or options['log_config'] is not None:
         logging.warning('Separate logging config file option has been deprecated.')
 
     # Set default for 'interval' as it is a new option so may not be in config.
     cp = ConfigParser.ConfigParser({'interval': 'latest'})
-    cp.read([options.config])
+    cp.read([options['config']])
 
     # set up logging
     try:
@@ -108,7 +119,7 @@ if __name__ == '__main__':
     db = None
 
     dbcp = ConfigParser.ConfigParser()
-    dbcp.read([options.db])
+    dbcp.read([options['db']])
 
     try:
         db = ApelDb(dbcp.get('db', 'backend'),

--- a/bin/parser.py
+++ b/bin/parser.py
@@ -35,7 +35,7 @@ import sys
 import re
 import gzip
 import bz2
-from optparse import OptionParser
+from argparse import ArgumentParser
 try:
     # Renamed ConfigParser to configparser in Python 3
     import configparser as ConfigParser
@@ -337,17 +337,28 @@ def main():
     install_exc_handler(default_handler)
 
     ver = "APEL parser %s.%s.%s" % __version__
-    opt_parser = OptionParser(description=__doc__, version=ver)
-    opt_parser.add_option("-c", "--config", help="location of config file",
-                          default="/etc/apel/parser.cfg")
-    opt_parser.add_option("-l", "--log_config", help="location of logging config file (optional)",
-                          default="/etc/apel/parserlog.cfg")
-    options, unused_args = opt_parser.parse_args()
+
+    default_conf_location = '/etc/apel/parser.cfg'
+    default_log_conf_location = '/etc/apel/parserlog.cfg'
+    arg_parser = ArgumentParser(description=__doc__)
+
+    arg_parser.add_argument('c', '--config',
+                            help='Location of config file',
+                            default=default_conf_location)
+    arg_parser.add_argument('-l', '--log_config',
+                            help='Location of logging config file (optional)',
+                            default=default_log_conf_location)
+    arg_parser.add_argument('-v', '--version',
+                            action='version',
+                            version=ver)
+
+    # Using the vars function to output a dict-like view rather than Namespace object.
+    options = vars(arg_parser.parse_args())
 
     # Read configuration from file
     try:
         cp = ConfigParser.ConfigParser()
-        cp.read(options.config)
+        cp.read(options['config'])
     except Exception as e:
         sys.stderr.write(str(e))
         sys.stderr.write('\n')
@@ -355,8 +366,8 @@ def main():
 
     # set up logging
     try:
-        if os.path.exists(options.log_config):
-            logging.config.fileConfig(options.log_config)
+        if os.path.exists(options['log_config']):
+            logging.config.fileConfig(options['log_config'])
         else:
             set_up_logging(cp.get('logging', 'logfile'),
                            cp.get('logging', 'level'),

--- a/bin/retrieve_dns.py
+++ b/bin/retrieve_dns.py
@@ -32,7 +32,7 @@ from future.builtins import object, str
 from apel.common import set_up_logging, LOG_BREAK
 from apel import __version__
 
-from optparse import OptionParser
+from argparse import ArgumentParser
 import logging.config
 import os
 import sys
@@ -355,15 +355,24 @@ def runprocess(config_file):
 
 if __name__ == '__main__':
     ver = "APEL auth %s.%s.%s" % __version__
-    opt_parser = OptionParser(description=__doc__, version=ver)
-    opt_parser.add_option('-c', '--config', help='location of the config file',
-                          default='/etc/apel/auth.cfg')
-    opt_parser.add_option('-l', '--log_config', help='DEPRECATED - location of logging config file',
-                          default=None)
-    options, args = opt_parser.parse_args()
+    default_conf_location = '/etc/apel/auth.cfg'
+    arg_parser = ArgumentParser(description=__doc__)
+
+    arg_parser.add_argument('-c', '--config',
+                            help='Location of the config file',
+                            default=default_conf_location)
+    arg_parser.add_argument('-l', '---log_config',
+                            help='DEPRECATED - Location of logging config file (optional)',
+                            default=None)
+    arg_parser.add_argument('-v', '--version',
+                            action='version',
+                            version=ver)
+
+    # Using the vars function to output a dict-like view rather than Namespace object.
+    options = vars(arg_parser.parse_args())
 
     # Deprecating functionality.
-    if os.path.exists('/etc/apel/logging.cfg') or options.log_config is not None:
+    if os.path.exists('/etc/apel/logging.cfg') or options['log_config'] is not None:
         logging.warning('Separate logging config file option has been deprecated.')
 
-    runprocess(options.config)
+    runprocess(options['config'])

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -24,7 +24,7 @@ from future import standard_library
 standard_library.install_aliases()
 from future.builtins import str
 
-from optparse import OptionParser
+from argparse import ArgumentParser
 import datetime
 import logging.config
 import os
@@ -177,17 +177,28 @@ if __name__ == '__main__':
     # Main method for running the summariser.
 
     ver = "APEL summariser %s.%s.%s" % __version__
-    opt_parser = OptionParser(description=__doc__, version=ver)
-    opt_parser.add_option('-d', '--db', help='the location of database config file',
-                          default='/etc/apel/db.cfg')
-    opt_parser.add_option('-c', '--config', help='the location of config file',
-                          default='/etc/apel/summariser.cfg')
-    opt_parser.add_option('-l', '--log_config', help='DEPRECATED - location of logging config file',
-                          default=None)
-    options,args = opt_parser.parse_args()
+    default_db_conf_file = '/etc/apel/db.cfg'
+    default_conf_file = '/etc/apel/summariser.cfg'
+    arg_parser = ArgumentParser(description=__doc__)
+
+    arg_parser.add_argument('-d', '--db',
+                            help='Location of database config file',
+                            default=default_db_conf_file)
+    arg_parser.add_argument('-c', '--config',
+                            help='Location of config file',
+                            default=default_conf_file)
+    arg_parser.add_argument('-l', '--log_config',
+                            help='DEPRECATED - Location of logging config file (optional)',
+                            default=None)
+    arg_parser.add_argument('-v', '--version',
+                            action='version',
+                            version=ver)
+
+    # Using the vars function to output a dict-like view rather than Namespace object.
+    options = vars(arg_parser.parse_args())
 
     # Deprecating functionality.
-    if os.path.exists('/etc/apel/logging.cfg') or options.log_config is not None:
+    if os.path.exists('/etc/apel/logging.cfg') or options['log_config'] is not None:
         logging.warning('Separate logging config file option has been deprecated.')
 
-    runprocess(options.db, options.config)
+    runprocess(options['db'], options['config'])


### PR DESCRIPTION
Optparse is deprecated - no longer developed. Mostly a like-for-like replacement, but we use vars on the argparse object to output the values in a similar way to optparse.

The old 'version' option on the constructor is unavailable, and so it has been replaced by adding an argument with the 'version' action.

Resolves #380 
Resolves GT-542