### PR TITLE
Fix typos

### DIFF
--- a/bin/dbloader.py
+++ b/bin/dbloader.py
@@ -136,7 +136,7 @@ if __name__ == '__main__':
 
     ver = "Starting APEL dbloader %s.%s.%s" % __version__
     default_db_conf_location = '/etc/apel/db.cfg'
-    default_conf_location = '/etc/apl/loader.cfg'
+    default_conf_location = '/etc/apel/loader.cfg'
     arg_parser = ArgumentParser()
 
     arg_parser.add_argument('-d', '--db',
@@ -153,7 +153,7 @@ if __name__ == '__main__':
                             version=ver)
 
     # Using the vars function to output a dict-like view rather than Namespace object.
-    options = arg_parser.parse_args()
+    options = vars(arg_parser.parse_args())
 
     # Deprecating functionality.
     if os.path.exists('/etc/apel/logging.cfg') or options['log_config'] is not None:


### PR DESCRIPTION
There were two errors within the parser file, a missed method (vars), as well as a typo in the logging file path.