### PR TITLE
Close temporary table.

### DIFF
--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -174,6 +174,7 @@ def runprocess(db_config_file, config_file):
 
         log.info(LOG_BREAK)
 
+
 if __name__ == '__main__':
     # Main method for running the summariser.
 

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -28,7 +28,6 @@ from argparse import ArgumentParser
 import datetime
 import logging.config
 import os
-import subprocess
 import sys
 try:
     # Renamed ConfigParser to configparser in Python 3
@@ -173,8 +172,7 @@ def runprocess(db_config_file, config_file):
 
         log.info(LOG_BREAK)
         db.db.close()
-        query = ('DROP DATABASE ' + db_name)
-        subprocess.call(['mysql', '-u', 'root', '-e', query])
+
 
 if __name__ == '__main__':
     # Main method for running the summariser.

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -28,6 +28,7 @@ from argparse import ArgumentParser
 import datetime
 import logging.config
 import os
+import subprocess
 import sys
 try:
     # Renamed ConfigParser to configparser in Python 3
@@ -171,7 +172,9 @@ def runprocess(db_config_file, config_file):
             log.warning("The summariser may not start again until it is removed.")
 
         log.info(LOG_BREAK)
-
+        db.db.close()
+        query = ('DROP DATABASE ' + db_name)
+        subprocess.call(['mysql', '-u', 'root', '-e', query])
 
 if __name__ == '__main__':
     # Main method for running the summariser.

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -157,6 +157,8 @@ def runprocess(db_config_file, config_file):
         log.error('Summarising has been cancelled.')
         sys.exit(1)
     finally:
+        # Close the database connection before final cleanup
+        db.db.close()
         # Clean up pidfile regardless of any excpetions
         # This even executes if sys.exit() is called
         log.info('Removing Pidfile')
@@ -171,8 +173,7 @@ def runprocess(db_config_file, config_file):
             log.warning("The summariser may not start again until it is removed.")
 
         log.info(LOG_BREAK)
-        db.db.close()
-
+    
 
 if __name__ == '__main__':
     # Main method for running the summariser.

--- a/bin/summariser.py
+++ b/bin/summariser.py
@@ -173,7 +173,6 @@ def runprocess(db_config_file, config_file):
             log.warning("The summariser may not start again until it is removed.")
 
         log.info(LOG_BREAK)
-    
 
 if __name__ == '__main__':
     # Main method for running the summariser.


### PR DESCRIPTION
Summariser sometimes complained about the temporary table already existing. This commit ensures the database connection is closed, avoiding hanging connections.

Resolves #392 