### PR TITLE
Fix trailing whitespace in header

### DIFF
--- a/apel/db/loader/record_factory.py
+++ b/apel/db/loader/record_factory.py
@@ -108,7 +108,7 @@ class RecordFactory(object):
                 except KeyError:
                     try:
                         # Use the full header to distinguish normalised and non-norm summaries.
-                        record_type = record_mapping[header]
+                        record_type = record_mapping[header.strip()]
                     except KeyError:
                         raise RecordFactoryException('Message type %s not recognised.' % header)
 

--- a/apel/db/unloader.py
+++ b/apel/db/unloader.py
@@ -272,7 +272,7 @@ class DbUnloader(object):
         record_type = type(records[0])
 
         buf = StringIO.StringIO()
-        buf.write(self.APEL_HEADERS[record_type] + ' \n')
+        buf.write(self.APEL_HEADERS[record_type] + '\n')
         buf.write('%%\n'.join( [ record.get_msg(self._withhold_dns) for record in records ] ))
         buf.write('%%\n')
 


### PR DESCRIPTION
Resolves #393 

This PR;
- fixes the full header matching (on loading) to trim whitespace before matching to the list of headers, as trailing whitespace was throwing this off before leading to rejected messages.
- removes the space added by the unloader after header. Due to changes in the way the loader now works, this additional whitespace was causing messages to be rejected as the header wasn't being trimmed before matching. While the incoming header is now trimmed by the previous commit, the unloaded header shouldn't have a trailing space anyway.