### PR TITLE
Replace assert with proper check

### DIFF
--- a/apel/db/records/record.py
+++ b/apel/db/records/record.py
@@ -185,7 +185,11 @@ class Record(object):
         '''
         Given a tuple from a mysql database, load fields.
         '''
-        assert len(tup) == len(self._db_fields), 'Different length of tuple and fields list'
+        if len(tup) != len(self._db_fields):
+            raise ValueError(
+                'Wrong tuple length. Expected %s items but got %s.'
+                % (len(self._db_fields), len(tup))
+            )
         self.set_all(dict(zip(self._db_fields, tup)))
 
     def load_from_msg(self, text):


### PR DESCRIPTION
Asserts get skipped in compiled Python code, so shouldn't be relied on for normal checks within the code. Replace this with a check on the lengths and raise a ValueError if they don't match.