### PR TITLE
Update unit test running to Ubuntu-22.04

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -31,8 +31,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Python versions on Rocky 8 and 9 respectively
-        python-version: ['3.9']
+        # Python versions on RHEL 9 and 10 respectively
+        python-version: ['3.9', '3.12']
     name: Python ${{ matrix.python-version }} test
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This unfortunately means no Python 3.6 available, but the unit tests aren't running anyway as ubuntu-20.04 has been removed as a runner.