### PR TITLE
Add config to recreate /var/run/apel folder on reboot

### DIFF
--- a/scripts/apel-build.sh
+++ b/scripts/apel-build.sh
@@ -111,6 +111,16 @@ mkdir -p "$TEMP_DIR_FOR_SERVER/var/run/apel"
 # apel-lib
 mkdir -p "$TEMP_DIR_FOR_LIB/$PYTHON_ROOT_DIR/$LIB_EXTENSION/apel/"
 
+# Ensure /var/run/apel is created at every reboot by systemd-tmpfiles
+# https://www.man7.org/linux/man-pages/man5/tmpfiles.d.5.html
+mkdir -p "$TEMP_DIR_FOR_SERVER/etc/tmpfiles.d"
+
+# Create a tmpfiles.d *.conf file using `cat` to manage the creation of /var/run/apel directory
+# https://www.uptimia.com/learn/linux-cat-command-useful-examples
+cat > "$TEMP_DIR_FOR_SERVER/etc/tmpfiles.d/run-apel.conf" <<EOF
+d /var/run/apel 0755 root root -
+EOF
+
 APEL_DIR=apel-$VERSION-$ITERATION
 
 # Download and extract source
@@ -240,6 +250,7 @@ FPM_SERVER_PACKAGE="-n apel-server \
     --config-files /etc/apel/loader.cfg \
     --config-files /etc/apel/db.cfg \
     --config-files /etc/apel/auth.cfg \
+    --config-files /etc/tmpfiles.d/run-apel.conf \
     --description \"APEL server package\" "
 
 FPM_LIB_PACKAGE="-n apel-lib \

--- a/scripts/apel-build.sh
+++ b/scripts/apel-build.sh
@@ -113,11 +113,11 @@ mkdir -p "$TEMP_DIR_FOR_LIB/$PYTHON_ROOT_DIR/$LIB_EXTENSION/apel/"
 
 # Ensure /var/run/apel is created at every reboot by systemd-tmpfiles
 # https://www.man7.org/linux/man-pages/man5/tmpfiles.d.5.html
-mkdir -p "$TEMP_DIR_FOR_SERVER/etc/tmpfiles.d"
+mkdir -p "$TEMP_DIR_FOR_SERVER/usr/lib/tmpfiles.d"
 
 # Create a tmpfiles.d *.conf file using `cat` to manage the creation of /var/run/apel directory
 # https://www.uptimia.com/learn/linux-cat-command-useful-examples
-cat > "$TEMP_DIR_FOR_SERVER/etc/tmpfiles.d/run-apel.conf" <<EOF
+cat > "$TEMP_DIR_FOR_SERVER/usr/lib/tmpfiles.d/apel-server.conf" <<EOF
 d /var/run/apel 0755 root root -
 EOF
 
@@ -250,7 +250,7 @@ FPM_SERVER_PACKAGE="-n apel-server \
     --config-files /etc/apel/loader.cfg \
     --config-files /etc/apel/db.cfg \
     --config-files /etc/apel/auth.cfg \
-    --config-files /etc/tmpfiles.d/run-apel.conf \
+    --config-files /usr/lib/tmpfiles.d/apel-server.conf \
     --description \"APEL server package\" "
 
 FPM_LIB_PACKAGE="-n apel-lib \


### PR DESCRIPTION
Resolves [GT-987]

There will another PR in APEL-SSM codebase to resolve the issue with SSM rpms

[GT-987]: https://stfc.atlassian.net/browse/GT-987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ