### PR TITLE
Add missing SyncRecord header when unloading dicts

### DIFF
--- a/apel/db/unloader.py
+++ b/apel/db/unloader.py
@@ -72,7 +72,8 @@ class DbUnloader(object):
 
     DICT_APEL_HEADERS = {JobRecord04: JOB_MSG_HEADER_04,
                          SummaryRecord04: SUMMARY_MSG_HEADER_04,
-                         NormalisedSummaryRecord04: NORMALISED_SUMMARY_MSG_HEADER_04}
+                         NormalisedSummaryRecord04: NORMALISED_SUMMARY_MSG_HEADER_04,
+                         SyncRecord: SYNC_MSG_HEADER}
 
 
     # all record types for which withholding DNs is a valid option


### PR DESCRIPTION
Resolves #419 

When the unloader is set to unload the new record format (dictionary benchmark field), it still needs to be able to retrieve the header for the SyncRecord type. This was an oversight during HEPscore development.