### PR TITLE
Update codebase and the schema to change cpu count type to decimal

### DIFF
--- a/apel/db/records/cloud.py
+++ b/apel/db/records/cloud.py
@@ -56,10 +56,10 @@ class CloudRecord(Record):
                                 "MeasurementMonth", "MeasurementYear"]
 
         # Fields which will have an integer stored in them
-        self._int_fields = [ "SuspendDuration", "WallDuration", "CpuDuration", "CpuCount",
+        self._int_fields = [ "SuspendDuration", "WallDuration", "CpuDuration",
                              "NetworkInbound", "NetworkOutbound", "PublicIPCount", "Memory", "Disk"]
 
-        self._float_fields = ['Benchmark']
+        self._float_fields = ['CpuCount', 'Benchmark']
         self._datetime_fields = ["RecordCreateTime", "StartTime", "EndTime"]
 
     def _check_fields(self):
@@ -100,7 +100,7 @@ class CloudRecord(Record):
         # table allowing it because the CloudSummaries table
         # doesn't allow it, creating a problem at summariser time.
         if self._record_content['CpuCount'] is None:
-            self._record_content['CpuCount'] = 0
+            self._record_content['CpuCount'] = 0.0
 
         # Check the values of StartTime and EndTime
         # self._check_start_end_times()

--- a/apel/db/records/cloud_summary.py
+++ b/apel/db/records/cloud_summary.py
@@ -53,8 +53,8 @@ class CloudSummaryRecord(Record):
 
         # Fields which will have an integer stored in them
         self._int_fields = ['Month', 'Year', 'WallDuration', 'CpuDuration',
-                            'CpuCount', 'NetworkInbound', 'NetworkOutbound',
+                            'NetworkInbound', 'NetworkOutbound',
                             'Memory', 'Disk', 'NumberOfVMs']
 
-        self._float_fields = ['Benchmark']
+        self._float_fields = ['CpuCount', 'Benchmark']
         self._datetime_fields = ['EarliestStartTime', 'LatestStartTime']

--- a/schemas/cloud.sql
+++ b/schemas/cloud.sql
@@ -32,7 +32,7 @@ CREATE TABLE CloudRecords (
   SuspendDuration BIGINT,
   WallDuration BIGINT,
   CpuDuration BIGINT,
-  CpuCount INT,
+  CpuCount DECIMAL(10,3) UNSIGNED,
 
   NetworkType VARCHAR(255),
   NetworkInbound BIGINT,
@@ -74,7 +74,7 @@ CREATE PROCEDURE ReplaceCloudRecord(
   startTime DATETIME, endTime DATETIME,
   suspendDuration BIGINT,
   wallDuration BIGINT, cpuDuration BIGINT,
-  cpuCount INT, networkType VARCHAR(255),  networkInbound BIGINT,
+  cpuCount DECIMAL(10,3) UNSIGNED, networkType VARCHAR(255),  networkInbound BIGINT,
   networkOutbound BIGINT, publicIPCount INT, memory BIGINT,
   disk BIGINT, benchmarkType VARCHAR(50), benchmark DECIMAL(10,3), storageRecordId VARCHAR(255),
   imageId VARCHAR(255), cloudType VARCHAR(255),
@@ -163,7 +163,7 @@ CREATE TABLE CloudSummaries (
   LatestStartTime DATETIME,
   WallDuration BIGINT,
   CpuDuration BIGINT,
-  CpuCount INT NOT NULL,
+  CpuCount DECIMAL(10,3) UNSIGNED NOT NULL,
 
   NetworkInbound BIGINT,
   NetworkOutbound BIGINT,
@@ -191,7 +191,7 @@ CREATE PROCEDURE ReplaceCloudSummaryRecord(
   vo VARCHAR(255), voGroup VARCHAR(255), voRole VARCHAR(255), status VARCHAR(255),
   cloudType VARCHAR(255), imageId VARCHAR(255),
   earliestStartTime DATETIME, latestStartTime DATETIME,
-  wallDuration BIGINT, cpuDuration BIGINT, cpuCount INT,
+  wallDuration BIGINT, cpuDuration BIGINT, cpuCount DECIMAL(10,3) UNSIGNED,
   networkInbound BIGINT, networkOutbound BIGINT, memory BIGINT,
   disk BIGINT, benchmarkType VARCHAR(50), benchmark DECIMAL(10,3), numberOfVMs BIGINT,
   publisherDN VARCHAR(255))

--- a/scripts/update-2.3.0-x.x.x.sql
+++ b/scripts/update-2.3.0-x.x.x.sql
@@ -1,0 +1,117 @@
+-- This script contains a SQL block that can update
+-- APEL version 2.3.0 databases of the following types to x.x.x:
+--  - Cloud Accounting Database
+
+-- UPDATE SCRIPT FOR CLOUD SCHEMA
+
+-- This section will:
+-- - Update CpuCount DBType in CloudRecords to DECIMAL(10,3) UNSIGNED from INT.
+-- - Update the ReplaceCloudRecord procedure to match this change.
+-- - Update CpuCount DBType in CloudSummaries to DECIMAL(10,3) UNSIGNED from INT.
+-- - Update the ReplaceCloudSummaryRecord procedure to match this change.
+
+-- CloudRecords
+ALTER TABLE CloudRecords MODIFY CpuCount DECIMAL(10,3) UNSIGNED;
+
+
+DROP PROCEDURE IF EXISTS ReplaceCloudRecord;
+DELIMITER //
+CREATE PROCEDURE ReplaceCloudRecord(
+  recordCreateTime DATETIME,VMUUID VARCHAR(255), site VARCHAR(255), cloudComputeService VARCHAR(255),
+  machineName VARCHAR(255),
+  localUserId VARCHAR(255),
+  localGroupId VARCHAR(255), globalUserName VARCHAR(255),
+  fqan VARCHAR(255), vo VARCHAR(255),
+  voGroup VARCHAR(255), voRole VARCHAR(255), status VARCHAR(255),
+  startTime DATETIME, endTime DATETIME,
+  suspendDuration BIGINT,
+  wallDuration BIGINT, cpuDuration BIGINT,
+  cpuCount DECIMAL(10,3) UNSIGNED, networkType VARCHAR(255),  networkInbound BIGINT,
+  networkOutbound BIGINT, publicIPCount INT, memory BIGINT,
+  disk BIGINT, benchmarkType VARCHAR(50), benchmark DECIMAL(10,3), storageRecordId VARCHAR(255),
+  imageId VARCHAR(255), cloudType VARCHAR(255),
+  publisherDN VARCHAR(255))
+
+BEGIN
+    DECLARE measurementTimeCalculated DATETIME;
+    DECLARE recordCreateTimeNotNull DATETIME;
+    DECLARE endTimeNotNull DATETIME;
+
+    IF(status='completed') THEN
+        -- in this case, the recordCreateTime and measurementTime could
+        -- be wildly different as the VM has ended.
+
+        -- if we werent supplied a record create time
+        -- for a completed VM we have decided to use the end time
+        -- We have to check the EndTime is not null because we can't guarantee this as we
+        -- previously loaded completed messages with no EndTime.
+        SET endTimeNotNull = IFNULL(endTime, '0000-00-00 00:00:00');
+        SET recordCreateTimeNotNull = IF(recordCreateTime IS NULL or recordCreateTime='0000-00-00 00:00:00', endTimeNotNull, recordCreateTime);
+
+        -- Use the end time as the measurement time
+        SET measurementTimeCalculated = endTimeNotNull;
+
+    ELSE
+        -- In the case of a running VM, the measurement time will
+        -- equal the record create time
+        IF(recordCreateTime IS NULL or recordCreateTime='0000-00-00 00:00:00') THEN
+            -- Calculate the time of measurement so we can use it later to determine which
+            -- accounting period this incoming record belongs too.
+            SET measurementTimeCalculated = TIMESTAMPADD(SECOND, (IFNULL(suspendDuration, 0) + IFNULL(wallDuration, 0)), startTime);
+            -- We recieve and currently accept messages without a start time
+            -- which causes the mesaurementTimeCalculated to be NULL
+            -- which causes a loader reject on a previously accepted message
+            -- so for now, set it to the zero time stamp as is what happens currently
+            SET measurementTimeCalculated = IFNULL(measurementTimeCalculated, '00-00-00 00:00:00');
+            SET recordCreateTimeNotNull = measurementTimeCalculated;
+        ELSE
+             -- Use the supplied record create time as the measurement time
+            SET measurementTimeCalculated = recordCreateTime;
+            SET recordCreateTimeNotNull = recordCreateTime;
+        END IF;
+    END IF;
+
+    REPLACE INTO CloudRecords(RecordCreateTime, VMUUID, SiteID, CloudComputeServiceID, MachineName,
+        LocalUserId, LocalGroupId, GlobalUserNameID, FQAN, VOID, VOGroupID,
+        VORoleID, Status, StartTime, EndTime, MeasurementTime, MeasurementMonth,
+        MeasurementYear, SuspendDuration, WallDuration, CpuDuration, CpuCount,
+        NetworkType, NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk,
+        BenchmarkType, Benchmark, StorageRecordId, ImageId, CloudType, PublisherDNID)
+      VALUES (
+        recordCreateTimeNotNull, VMUUID, SiteLookup(site), CloudComputeServiceLookup(cloudComputeService), machineName,
+        localUserId, localGroupId, DNLookup(globalUserName), fqan, VOLookup(vo), VOGroupLookup(voGroup),
+        VORoleLookup(voRole), status, startTime, endTime, measurementTimeCalculated, Month(measurementTimeCalculated), Year(measurementTimeCalculated),
+        suspendDuration, wallDuration, cpuDuration, cpuCount,
+        networkType, networkInbound, networkOutbound, publicIPCount, memory, disk,
+        benchmarkType, benchmark, storageRecordId, imageId, cloudType, DNLookup(publisherDN))
+    ;
+END //
+DELIMITER ;
+
+
+-- CloudSummaries
+ALTER TABLE CloudSummaries MODIFY CpuCount DECIMAL(10,3) UNSIGNED;
+
+
+DROP PROCEDURE IF EXISTS ReplaceCloudSummaryRecord;
+DELIMITER //
+CREATE PROCEDURE ReplaceCloudSummaryRecord(
+  site VARCHAR(255), cloudComputeService VARCHAR(255), month INT, year INT, globalUserName VARCHAR(255),
+  vo VARCHAR(255), voGroup VARCHAR(255), voRole VARCHAR(255), status VARCHAR(255),
+  cloudType VARCHAR(255), imageId VARCHAR(255),
+  earliestStartTime DATETIME, latestStartTime DATETIME,
+  wallDuration BIGINT, cpuDuration BIGINT, cpuCount DECIMAL(10,3) UNSIGNED,
+  networkInbound BIGINT, networkOutbound BIGINT, memory BIGINT,
+  disk BIGINT, benchmarkType VARCHAR(50), benchmark DECIMAL(10,3), numberOfVMs BIGINT,
+  publisherDN VARCHAR(255))
+BEGIN
+    REPLACE INTO CloudSummaries(SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId, EarliestStartTime, LatestStartTime,
+        WallDuration, CpuDuration, CpuCount, NetworkInbound, NetworkOutbound, Memory, Disk, BenchmarkType, Benchmark, NumberOfVMs,  PublisherDNID)
+      VALUES (
+        SiteLookup(site), CloudComputeServiceLookup(cloudComputeService), month, year, DNLookup(globalUserName), VOLookup(vo),
+        VOGroupLookup(voGroup), VORoleLookup(voRole), status, cloudType, imageId, earliestStartTime, latestStartTime,
+        wallDuration, cpuDuration, cpuCount, networkInbound, networkOutbound, memory,
+        disk, benchmarkType, benchmark, numberOfVMs, DNLookup(publisherDN)
+        );
+END //
+DELIMITER ;

--- a/scripts/update-2.3.0-x.x.x.sql
+++ b/scripts/update-2.3.0-x.x.x.sql
@@ -56,10 +56,10 @@ BEGIN
         -- equal the record create time
         IF(recordCreateTime IS NULL or recordCreateTime='0000-00-00 00:00:00') THEN
             -- Calculate the time of measurement so we can use it later to determine which
-            -- accounting period this incoming record belongs too.
+            -- accounting period this incoming record belongs to.
             SET measurementTimeCalculated = TIMESTAMPADD(SECOND, (IFNULL(suspendDuration, 0) + IFNULL(wallDuration, 0)), startTime);
-            -- We recieve and currently accept messages without a start time
-            -- which causes the mesaurementTimeCalculated to be NULL
+            -- We receive and currently accept messages without a start time
+            -- which causes the measurementTimeCalculated to be NULL
             -- which causes a loader reject on a previously accepted message
             -- so for now, set it to the zero time stamp as is what happens currently
             SET measurementTimeCalculated = IFNULL(measurementTimeCalculated, '00-00-00 00:00:00');
@@ -80,8 +80,8 @@ BEGIN
       VALUES (
         recordCreateTimeNotNull, VMUUID, SiteLookup(site), CloudComputeServiceLookup(cloudComputeService), machineName,
         localUserId, localGroupId, DNLookup(globalUserName), fqan, VOLookup(vo), VOGroupLookup(voGroup),
-        VORoleLookup(voRole), status, startTime, endTime, measurementTimeCalculated, Month(measurementTimeCalculated), Year(measurementTimeCalculated),
-        suspendDuration, wallDuration, cpuDuration, cpuCount,
+        VORoleLookup(voRole), status, startTime, endTime, measurementTimeCalculated, Month(measurementTimeCalculated),
+        Year(measurementTimeCalculated), suspendDuration, wallDuration, cpuDuration, cpuCount,
         networkType, networkInbound, networkOutbound, publicIPCount, memory, disk,
         benchmarkType, benchmark, storageRecordId, imageId, cloudType, DNLookup(publisherDN))
     ;
@@ -112,6 +112,6 @@ BEGIN
         VOGroupLookup(voGroup), VORoleLookup(voRole), status, cloudType, imageId, earliestStartTime, latestStartTime,
         wallDuration, cpuDuration, cpuCount, networkInbound, networkOutbound, memory,
         disk, benchmarkType, benchmark, numberOfVMs, DNLookup(publisherDN)
-        );
+      );
 END //
 DELIMITER ;

--- a/test/test_cloud_record.py
+++ b/test/test_cloud_record.py
@@ -56,7 +56,7 @@ EndTime: 1318848076
 SuspendDuration: NULL
 WallDuration: NULL
 CpuDuration: NULL
-CpuCount: 1
+CpuCount: 1.0000
 NetworkType: NULL
 NetworkInbound: 0
 NetworkOutbound: 0
@@ -74,7 +74,7 @@ CloudType: OpenNebula
                         'MachineName': '\'one-0\'',
                         'LocalUserId': '5',
                         'Status': 'completed',
-                        'CpuCount': 1,
+                        'CpuCount': 1.000,
                         'PublicIPCount': 5,
                         'Memory': 512,
                         'BenchmarkType': 'Hepspec',
@@ -98,7 +98,7 @@ EndTime: NULL
 SuspendDuration: NULL
 WallDuration: 1582876
 CpuDuration: 437
-CpuCount: 1
+CpuCount: 1.456
 NetworkType: NULL
 NetworkInbound: NULL
 NetworkOutbound: NULL
@@ -122,7 +122,7 @@ CloudType: Openstack
                         'VOGroup': '/ops',
                         'VORole': 'Role=NULL',
                         'Status': 'started',
-                        'CpuCount': 1,
+                        'CpuCount': 1.456,
                         'PublicIPCount': 1,
                         'Memory': 512,
                         'BenchmarkType': 'Si2k',
@@ -147,7 +147,7 @@ EndTime: 1318849976
 SuspendDuration: NULL
 WallDuration: NULL
 CpuDuration: NULL
-CpuCount: 1
+CpuCount: 2
 NetworkType: NULL
 NetworkInbound: 0
 NetworkOutbound: 0
@@ -163,7 +163,7 @@ CloudType: OpenNebula
                          'MachineName': '\'one-1\'',
                          'LocalUserId': '5',
                          'Status': 'completed',
-                         'CpuCount': 1,
+                         'CpuCount': 2.0,
                          'PublicIPCount': None,
                          'Memory': 512,
                          'BenchmarkType': 'None',
@@ -199,7 +199,7 @@ CloudComputeService: Test Service'''
                          'SuspendDuration': None,
                          'WallDuration': None,
                          'CpuDuration': None,
-                         'CpuCount': 0,
+                         'CpuCount': 0.0,
                          'NetworkType': 'None',
                          'NetworkInbound': None,
                          'NetworkOutbound': None,

--- a/test/test_cloud_record.py
+++ b/test/test_cloud_record.py
@@ -56,7 +56,7 @@ EndTime: 1318848076
 SuspendDuration: NULL
 WallDuration: NULL
 CpuDuration: NULL
-CpuCount: 1.0000
+CpuCount: 1.000
 NetworkType: NULL
 NetworkInbound: 0
 NetworkOutbound: 0

--- a/test/test_cloud_summary.py
+++ b/test/test_cloud_summary.py
@@ -25,7 +25,7 @@ EarliestStartTime: 1318840264
 LatestStartTime: 1318840264
 WallDuration: None
 CpuDuration: None
-CpuCount: 4
+CpuCount: 4.0
 NetworkInbound: 0
 NetworkOutbound: 0
 Memory: 512

--- a/test/test_mysql.py
+++ b/test/test_mysql.py
@@ -300,7 +300,7 @@ EndTime: 1318849976
 SuspendDuration: NULL
 WallDuration: NULL
 CpuDuration: NULL
-CpuCount: 1
+CpuCount: 1.234
 NetworkType: NULL
 NetworkInbound: 0
 NetworkOutbound: 0
@@ -325,7 +325,7 @@ EndTime: NULL
 SuspendDuration: NULL
 WallDuration: 1582876
 CpuDuration: 437
-CpuCount: 1
+CpuCount: 1.345
 NetworkType: NULL
 NetworkInbound: NULL
 NetworkOutbound: NULL
@@ -354,7 +354,7 @@ EndTime: NULL
 SuspendDuration: NULL
 WallDuration: 1583876
 CpuDuration: 438
-CpuCount: 1
+CpuCount: 2
 NetworkType: NULL
 NetworkInbound: NULL
 NetworkOutbound: NULL


### PR DESCRIPTION
Will need the schema update script finalising in terms of version numbers and rebasing once 2.3.1 is done.

To check:
- [x] That `DECIMAL(10,3)` is big enough for existing `CpuCount` values or if we need (13,3) for safety.
-> Biggest value in DB is 128 CPUs. ✅ 

This code was tested as part of the interTwin project and ran successfully there. Requires #441 to enable the option to unload decimal CPU counts as decimal or integer (for EGI Portal compatibility).