### PR TITLE
Set config value to upload optional decimal cpu count

### DIFF
--- a/apel/db/records/cloud.py
+++ b/apel/db/records/cloud.py
@@ -133,6 +133,19 @@ class CloudRecord(Record):
             raise InvalidRecordException("Cannot parse an integer from StartTime or EndTime.")
 
 
+    '''
+    Move a field from one type category to another.
+
+    This updates the internal type lists by removing `field_name` from the
+    list associated with `from_type` and appending it to the list associated
+    with `to_type`. The method only performs the change if the field is
+    currently present in the source type list.
+    Notes
+    -----
+    - No action is taken if from_type is not a valid key in the internal
+      type mapping or if the field is not present in the source list.
+    - This method assumes that to_type is a valid key in the type map.
+    '''
     def change_field_type(self, field_name, from_type, to_type):
         type_map = {
             'float': self._float_fields,

--- a/apel/db/records/cloud.py
+++ b/apel/db/records/cloud.py
@@ -131,3 +131,14 @@ class CloudRecord(Record):
 
         except (ValueError, OverflowError, OSError):
             raise InvalidRecordException("Cannot parse an integer from StartTime or EndTime.")
+
+
+    def change_field_type(self, field_name, from_type, to_type):
+        type_map = {
+            'float': self._float_fields,
+            'int': self._int_fields
+        }
+
+        if from_type in type_map and field_name in type_map[from_type]:
+            type_map[from_type].remove(field_name)
+            type_map[to_type].append(field_name)

--- a/apel/db/unloader.py
+++ b/apel/db/unloader.py
@@ -240,7 +240,7 @@ class DbUnloader(object):
         for batch in self._db.get_records(record_type, table_name, query=query, records_per_message=self.records_per_message):
             if record_type == CloudRecord and not self._decimal_cpu_count:
                 for row in batch:
-                    row._record_content['CpuCount'] = self._to_int_min1(row._record_content.get('CpuCount'))
+                    row.set_field('CpuCount', self._to_int_min1(row.get_field('CpuCount')))
 
             records += len(batch)
             if ur:

--- a/apel/db/unloader.py
+++ b/apel/db/unloader.py
@@ -240,6 +240,7 @@ class DbUnloader(object):
         for batch in self._db.get_records(record_type, table_name, query=query, records_per_message=self.records_per_message):
             if record_type == CloudRecord and not self._decimal_cpu_count:
                 for row in batch:
+                    row.change_field_type('CpuCount', 'float', 'int')
                     row.set_field('CpuCount', self._to_int_min1(row.get_field('CpuCount')))
 
             records += len(batch)

--- a/apel/db/unloader.py
+++ b/apel/db/unloader.py
@@ -240,7 +240,7 @@ class DbUnloader(object):
         for batch in self._db.get_records(record_type, table_name, query=query, records_per_message=self.records_per_message):
             if record_type == CloudRecord and not self._decimal_cpu_count:
                 for row in batch:
-                    row['CpuCount'] = self._to_int_min1(row.get('CpuCount'))
+                    row._record_content['CpuCount'] = self._to_int_min1(row._record_content.get('CpuCount'))
 
             records += len(batch)
             if ur:
@@ -254,11 +254,12 @@ class DbUnloader(object):
     def _to_int_min1(self, v):
         '''
         Convert a value to an integer with a special rule:
-        - If the numeric value is less than 1 (v < 1), return 1.
+        - If the numeric value is less than 1 and greater than 0 (0 < v < 1), return 1.
         - For all other numeric values, return int(v).
         - Return None if the value cannot be interpreted as a number.
 
         Examples:
+            to_int_min1(0)  -> 0
             to_int_min1("0.6")  -> 1
             to_int_min1(0.2)    -> 1
             to_int_min1("12")   -> 12
@@ -277,7 +278,7 @@ class DbUnloader(object):
             return None
 
         # Apply special rule for values in (0, 1).
-        if fv < 1.0:
+        if 0 < fv < 1.0:
             return 1
 
         # Normal integer conversion.

--- a/apel/db/unloader.py
+++ b/apel/db/unloader.py
@@ -238,7 +238,7 @@ class DbUnloader(object):
         msgs = 0
         records = 0
         for batch in self._db.get_records(record_type, table_name, query=query, records_per_message=self.records_per_message):
-            if record_type == CloudRecord and self._decimal_cpu_count:
+            if record_type == CloudRecord and not self._decimal_cpu_count:
                 for row in batch:
                     row['CpuCount'] = self._to_int_min1(row.get('CpuCount'))
 
@@ -250,8 +250,8 @@ class DbUnloader(object):
             msgs += 1
 
         return msgs, records
-    
-    def _to_int_min1(v):
+
+    def _to_int_min1(self, v):
         '''
         Convert a value to an integer with a special rule:
         - If the numeric value is less than 1 (v < 1), return 1.

--- a/apel/db/unloader.py
+++ b/apel/db/unloader.py
@@ -269,7 +269,8 @@ class DbUnloader(object):
         if v is None:
             return None
 
-        # Convert to float first — it handles ints, floats, and numeric strings ("0.6", "12.0").
+        # Convert to float first — it handles ints, floats,
+        # and numeric strings ("0.6", "12.0").
         try:
             fv = float(v)
         except (ValueError, TypeError):

--- a/apel/db/unloader.py
+++ b/apel/db/unloader.py
@@ -80,7 +80,7 @@ class DbUnloader(object):
     MAY_WITHHOLD_DNS = [JobRecord, SyncRecord, CloudRecord]
 
     def __init__(self, db, qpath, inc_vos=None, exc_vos=None, local=False, withhold_dns=False,
-                 dict_records=False):
+                 dict_records=False, decimal_cpu_count=False):
         self._db = db
         outpath = os.path.join(qpath, "outgoing")
         self._msgq = QueueSimple(outpath)
@@ -88,6 +88,7 @@ class DbUnloader(object):
         self._exc_vos = exc_vos
         self._local = local
         self._withhold_dns = withhold_dns
+        self._decimal_cpu_count = decimal_cpu_count
         self.records_per_message = 1000
         if dict_records:
             # If dict_records is True, then we only handle the subset of v0.4 records
@@ -237,6 +238,10 @@ class DbUnloader(object):
         msgs = 0
         records = 0
         for batch in self._db.get_records(record_type, table_name, query=query, records_per_message=self.records_per_message):
+            if record_type == CloudRecord and self._decimal_cpu_count:
+                for row in batch:
+                    row['CpuCount'] = self._to_int_min1(row.get('CpuCount'))
+
             records += len(batch)
             if ur:
                 self._write_xml(batch)
@@ -245,6 +250,37 @@ class DbUnloader(object):
             msgs += 1
 
         return msgs, records
+    
+    def _to_int_min1(v):
+        '''
+        Convert a value to an integer with a special rule:
+        - If the numeric value is less than 1 (v < 1), return 1.
+        - For all other numeric values, return int(v).
+        - Return None if the value cannot be interpreted as a number.
+
+        Examples:
+            to_int_min1("0.6")  -> 1
+            to_int_min1(0.2)    -> 1
+            to_int_min1("12")   -> 12
+            to_int_min1("12.8") -> 12
+            to_int_min1(None)   -> None
+            to_int_min1("N/A")  -> None
+        '''
+        if v is None:
+            return None
+
+        # Convert to float first — it handles ints, floats, and numeric strings ("0.6", "12.0").
+        try:
+            fv = float(v)
+        except (ValueError, TypeError):
+            return None
+
+        # Apply special rule for values in (0, 1).
+        if fv < 1.0:
+            return 1
+
+        # Normal integer conversion.
+        return int(fv)
 
     def _write_xml(self, records):
         '''

--- a/apel/db/unloader.py
+++ b/apel/db/unloader.py
@@ -257,15 +257,6 @@ class DbUnloader(object):
         - If the numeric value is less than 1 and greater than 0 (0 < v < 1), return 1.
         - For all other numeric values, return int(v).
         - Return None if the value cannot be interpreted as a number.
-
-        Examples:
-            to_int_min1(0)  -> 0
-            to_int_min1("0.6")  -> 1
-            to_int_min1(0.2)    -> 1
-            to_int_min1("12")   -> 12
-            to_int_min1("12.8") -> 12
-            to_int_min1(None)   -> None
-            to_int_min1("N/A")  -> None
         '''
         if v is None:
             return None

--- a/bin/dbunloader.py
+++ b/bin/dbunloader.py
@@ -154,12 +154,12 @@ if __name__ == '__main__':
         local_jobs = False
 
     try:
-        withhold_dns     = cp.getboolean('unloader', 'withhold_dns')
+        withhold_dns = cp.getboolean('unloader', 'withhold_dns')
     except ConfigParser.NoOptionError:
         withhold_dns = False
 
     try:
-        decimal_cpu_count     = cp.getboolean('unloader', 'decimal_cpu_count')
+        decimal_cpu_count = cp.getboolean('unloader', 'decimal_cpu_count')
     except ConfigParser.NoOptionError:
         decimal_cpu_count = False
 

--- a/bin/dbunloader.py
+++ b/bin/dbunloader.py
@@ -178,7 +178,8 @@ if __name__ == '__main__':
 
     interval = cp.get('unloader', 'interval')
 
-    unloader = DbUnloader(db, unload_dir, include_vos, exclude_vos, local_jobs, withhold_dns, dict_records, decimal_cpu_count)
+    unloader = DbUnloader(db, unload_dir, include_vos, exclude_vos, local_jobs,
+                          withhold_dns, dict_records, decimal_cpu_count)
 
     unloader.records_per_message = _bounded_records_per_message(cp, log)
 

--- a/bin/dbunloader.py
+++ b/bin/dbunloader.py
@@ -158,6 +158,11 @@ if __name__ == '__main__':
     except ConfigParser.NoOptionError:
         withhold_dns = False
 
+    try:
+        decimal_cpu_count     = cp.getboolean('unloader', 'decimal_cpu_count')
+    except ConfigParser.NoOptionError:
+        decimal_cpu_count = False
+
     include_vos      = None
     exclude_vos      = None
     try:
@@ -173,7 +178,7 @@ if __name__ == '__main__':
 
     interval = cp.get('unloader', 'interval')
 
-    unloader = DbUnloader(db, unload_dir, include_vos, exclude_vos, local_jobs, withhold_dns, dict_records)
+    unloader = DbUnloader(db, unload_dir, include_vos, exclude_vos, local_jobs, withhold_dns, dict_records, decimal_cpu_count)
 
     unloader.records_per_message = _bounded_records_per_message(cp, log)
 

--- a/conf/unloader.cfg
+++ b/conf/unloader.cfg
@@ -56,7 +56,7 @@ gap_start = 2014-01-01
 gap_end = 2014-01-31
 
 # Option to either unload decimal or integer CPU count for Cloud records from repo to portal
-decimal_cpu_count = true
+decimal_cpu_count = false
 
 # Number of records to pull from the database in a single query and pass to the
 # queue in a single message. Must be an integer between 1 and 5000 (inclusive).

--- a/conf/unloader.cfg
+++ b/conf/unloader.cfg
@@ -55,6 +55,9 @@ interval = latest
 gap_start = 2014-01-01
 gap_end = 2014-01-31
 
+# Option to either unload decimal or integer CPU count for Cloud records from repo to portal
+decimal_cpu_count = true
+
 # Number of records to pull from the database in a single query and pass to the
 # queue in a single message. Must be an integer between 1 and 5000 (inclusive).
 # Defaults to 1000 records.

--- a/conf/unloader.cfg
+++ b/conf/unloader.cfg
@@ -55,7 +55,7 @@ interval = latest
 gap_start = 2014-01-01
 gap_end = 2014-01-31
 
-# Option to either unload decimal or integer CPU count for Cloud records from repo to portal
+# For cloud records only, unload decimal CPU counts if available in the DB (if true) or coerce to integers (if false)
 decimal_cpu_count = false
 
 # Number of records to pull from the database in a single query and pass to the

--- a/test/test_unloader.py
+++ b/test/test_unloader.py
@@ -36,7 +36,7 @@ class TestDbUnloader(unittest.TestCase):
         self.assertEqual(self.unloader._to_int_min1("0.6"), 1)
 
     def test_to_int_min1_zero_and_one(self):
-        self.assertEqual(self.unloader._to_int_min1(0), 1)
+        self.assertEqual(self.unloader._to_int_min1(0), 0)
         self.assertEqual(self.unloader._to_int_min1(1), 1)
         self.assertEqual(self.unloader._to_int_min1("1"), 1)
 

--- a/test/test_unloader.py
+++ b/test/test_unloader.py
@@ -26,6 +26,25 @@ class TestDbUnloader(unittest.TestCase):
         self.assertRaises(ApelDbException, self.unloader._write_messages,
                           StorageRecord, 'table', 'query', ur=False)
 
+    def test_to_int_min1_basic(self):
+        self.assertEqual(self.unloader._to_int_min1(5), 5)
+        self.assertEqual(self.unloader._to_int_min1(5.5), 5)
+        self.assertEqual(self.unloader._to_int_min1("5"), 5)
+
+    def test_to_int_min1_fraction_less_than_one(self):
+        self.assertEqual(self.unloader._to_int_min1(0.6), 1)
+        self.assertEqual(self.unloader._to_int_min1("0.6"), 1)
+
+    def test_to_int_min1_zero_and_one(self):
+        self.assertEqual(self.unloader._to_int_min1(0), 1)
+        self.assertEqual(self.unloader._to_int_min1(1), 1)
+        self.assertEqual(self.unloader._to_int_min1("1"), 1)
+
+    def test_to_int_min1_invalid_values(self):
+        self.assertIsNone(self.unloader._to_int_min1("N/A"))
+        self.assertIsNone(self.unloader._to_int_min1(None))
+        self.assertIsNone(self.unloader._to_int_min1([]))
+
 
 class TestFunctions(unittest.TestCase):
     """Test cases for non-class functions."""


### PR DESCRIPTION
Resolves GT-1297

Manual testing:
- Update config file at `/etc/apel/cloud/cloud-unloader.cfg`
```
table_name=VCloudSummaries
decimal_cpu_count = true
```
- Update latest code for `unloader.py` at `/usr/lib/python3.9/site-packages/apel/db`
- Update `apeldbunloader` at `/usr/bin`
- Set up database schema and table
- Populate `/etc/apel/cloud/cloud-db.cfg` with appropriate value
- Run `/usr/bin/apeldbunloader -d /etc/apel/cloud/cloud-db.cfg -c /etc/apel/cloud/cloud-unloader.cfg`
- Test the result at `/var/spool/apel/cloud/outgoing`
