### PR TITLE
Convert cursorclass named arguments to positional in cursor calls

### DIFF
--- a/apel/db/backends/mysql.py
+++ b/apel/db/backends/mysql.py
@@ -164,7 +164,7 @@ class ApelMysqlDb(object):
             # 'MySQL server has gone' exception
             self._mysql_reconnect()
 
-            c = self.db.cursor(cursorclass=MySQLdb.cursors.DictCursor)
+            c = self.db.cursor(MySQLdb.cursors.DictCursor)
 
             for record in record_list:
                 values = record.get_db_tuple(source)
@@ -227,7 +227,7 @@ class ApelMysqlDb(object):
             # 'MySQL server has gone' exception
             self._mysql_reconnect()
 
-            c = self.db.cursor(cursorclass=MySQLdb.cursors.SSDictCursor)
+            c = self.db.cursor(MySQLdb.cursors.SSDictCursor)
             c.execute(query_string)
             while True:
                 for row in c.fetchmany(size=records_per_message):

--- a/scripts/migrate_apel.py
+++ b/scripts/migrate_apel.py
@@ -126,7 +126,7 @@ def copy_records(db1, db2, cutoff):
     Copy all records from the LcgRecords table in db1 to the JobRecords
     table in db2 whose EndTime is greater than the cutoff datetime.
     '''
-    c1 = db1.cursor(cursorclass=MySQLdb.cursors.SSCursor)
+    c1 = db1.cursor(MySQLdb.cursors.SSCursor)
     c2 = db2.cursor()
 
     remove_proc(c2)


### PR DESCRIPTION
- as some python db packages have differing arg naming conventions (e.g: cursorclass and cursor)
- but both seen so far have it as the only positional argument

Resolves #443
Resolves GT-1372