### PR TITLE
Extend coercion to integer for decimal CPU counts to Cloud Summaries

### DIFF
--- a/apel/db/records/cloud.py
+++ b/apel/db/records/cloud.py
@@ -131,27 +131,3 @@ class CloudRecord(Record):
 
         except (ValueError, OverflowError, OSError):
             raise InvalidRecordException("Cannot parse an integer from StartTime or EndTime.")
-
-
-    '''
-    Move a field from one type category to another.
-
-    This updates the internal type lists by removing `field_name` from the
-    list associated with `from_type` and appending it to the list associated
-    with `to_type`. The method only performs the change if the field is
-    currently present in the source type list.
-    Notes
-    -----
-    - No action is taken if from_type is not a valid key in the internal
-      type mapping or if the field is not present in the source list.
-    - This method assumes that to_type is a valid key in the type map.
-    '''
-    def change_field_type(self, field_name, from_type, to_type):
-        type_map = {
-            'float': self._float_fields,
-            'int': self._int_fields
-        }
-
-        if from_type in type_map and field_name in type_map[from_type]:
-            type_map[from_type].remove(field_name)
-            type_map[to_type].append(field_name)

--- a/apel/db/records/record.py
+++ b/apel/db/records/record.py
@@ -125,6 +125,30 @@ class Record(object):
                 return None
 
 
+    def change_field_type(self, field_name, from_type, to_type):
+        '''
+        Move a field from one type category to another.
+
+        This updates the internal type lists by removing `field_name` from the
+        list associated with `from_type` and appending it to the list associated
+        with `to_type`. The method only performs the change if the field is
+        currently present in the source type list.
+        Notes
+        -----
+        - No action is taken if from_type is not a valid key in the internal
+        type mapping or if the field is not present in the source list.
+        - This method assumes that to_type is a valid key in the type map.
+        '''
+        type_map = {
+            'float': self._float_fields,
+            'int': self._int_fields
+        }
+
+        if from_type in type_map and field_name in type_map[from_type]:
+            type_map[from_type].remove(field_name)
+            type_map[to_type].append(field_name)
+
+
     def checked(self, name, value):
         '''
         Returns value converted to correct type if this is possible.

--- a/apel/db/unloader.py
+++ b/apel/db/unloader.py
@@ -239,7 +239,7 @@ class DbUnloader(object):
         msgs = 0
         records = 0
         for batch in self._db.get_records(record_type, table_name, query=query, records_per_message=self.records_per_message):
-            if record_type == CloudRecord and not self._decimal_cpu_count:
+            if record_type in (CloudRecord, CloudSummaryRecord) and not self._decimal_cpu_count:
                 for row in batch:
                     row.change_field_type('CpuCount', 'float', 'int')
                     row.set_field('CpuCount', self._to_int_min1(row.get_field('CpuCount')))

--- a/test/test_record.py
+++ b/test/test_record.py
@@ -51,6 +51,21 @@ class RecordTest(unittest.TestCase):
                 print("Value Error not raised for '%s'" % value)
                 raise
 
+    def test_change_field_type(self):
+        """Basic test of field type changing."""
+        record = Record()
+        record._int_fields = ['IntField', 'IntToFloatField']
+        record._float_fields = ['FloatField', 'FloatToIntField']
+
+        self.assertEqual(record._int_fields, ['IntField', 'IntToFloatField'])
+        self.assertEqual(record._float_fields, ['FloatField', 'FloatToIntField'])
+
+        record.change_field_type('IntToFloatField', 'int', 'float')
+        record.change_field_type('FloatToIntField', 'float', 'int')
+
+        self.assertEqual(record._int_fields, ['IntField', 'FloatToIntField'])
+        self.assertEqual(record._float_fields, ['FloatField', 'IntToFloatField'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Resolves #463 

Manual Testing Steps


1. Update `/etc/apel/cloud/cloud-unloader.cfg`:
    - Set decimal_cpu_count to true, then repeat with false.
    - Set table_name to VCloudRecords, then repeat with VCloudSummaries.
2. Run `/usr/bin/apeldbunloader -d /etc/apel/cloud/cloud-db.cfg -c /etc/apel/cloud/cloud-unloader.cfg`
3. After each configuration change, verify the output generated in:
`/var/spool/apel/cloud/outgoing`