### PR TITLE
Replace assertions with ValueError

### DIFF
--- a/apel/parsers/sge.py
+++ b/apel/parsers/sge.py
@@ -156,10 +156,12 @@ class SGEParser(Parser):
         for key in mapping:
             data[key] = mapping[key](values)
 
-        assert data['CpuDuration'] >= 0, 'Negative CpuDuration value'
-        assert data['WallDuration'] >= 0, 'Negative WallDuration value'
-        assert data['StopTime'] > 0, 'Zero epoch time for field StopTime'
-
+        if data['CpuDuration'] < 0:
+            raise ValueError("Negative CpuDuration value: %s" % data['CpuDuration'])
+        if data['WallDuration'] < 0:
+            raise ValueError("Negative WallDuration value: %s" % data['WallDuration'])
+        if data['StopTime'] <= 0:
+            raise ValueError("Zero epoch time for field StopTime")
 
         record.set_all(data)
 

--- a/test/test_sge.py
+++ b/test/test_sge.py
@@ -365,6 +365,26 @@ class ParserSGETest(unittest.TestCase):
         self.assertEqual(record._record_content['Processors'], 0,
                          "Processors not zero for non-mpi parser")
 
+    def test_negative_values(self):
+        """Check that negative values for durations and StopTime raise a ValueError"""
+        lines = (
+            'dteam:testce.test:dteam:dteam041:STDIN:43:sge:19:1200093286:1200093294:'
+            '1200093295:0:0:-1:0:0:0.000000:0:0:0:0:46206:0:0:0.000000:0:0:0:0:337:'
+            '257:NONE:defaultdepartment:NONE:1:0:0.090000:0.000213:0.000000:'
+            '-U dteam -q dteam:0.000000:NONE:30171136.000000',
+            'dteam:testce.test:dteam:dteam041:STDIN:43:sge:19:1200093286:1200093294:'
+            '1200093295:0:0:1:0:0:0.000000:0:0:0:0:46206:0:0:0.000000:0:0:0:0:337:'
+            '257:NONE:defaultdepartment:NONE:1:0:-0.900000:0.000213:0.000000:'
+            '-U dteam -q dteam:0.000000:NONE:30171136.000000',
+            'dteam:testce.test:dteam:dteam041:STDIN:43:sge:19:1200093286:1200093294:'
+            '-1200093295:0:0:1:0:0:0.000000:0:0:0:0:46206:0:0:0.000000:0:0:0:0:337:'
+            '257:NONE:defaultdepartment:NONE:1:0:0.090000:0.000213:0.000000:'
+            '-U dteam -q dteam:0.000000:NONE:30171136.000000'
+        )
+        parser = apel.parsers.SGEParser('testSite', 'testHost', False)
+        for line in lines:
+            self.assertRaises(ValueError, parser.parse, line)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Resolved: https://github.com/apel/apel/issues/412
Replace assertions with ValueError to ensures validation is always performed, even when Python assertions are disabled